### PR TITLE
docs(agents): add AGENTS.md scoped to subagent definitions (#114)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+# AGENTS.md
+
+Subagent definitions for AI agents working in this repository.
+
+Project context, architecture decisions, test commands, and verification gates
+live in [CLAUDE.md](CLAUDE.md) and [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) —
+they are intentionally **not** repeated here. Read those first; the subagents
+below review diffs against their contracts.
+
+## Available Subagents
+
+### sync-point-reviewer
+
+```markdown
+---
+name: sync-point-reviewer
+description: Reviews Python changes for parity between the installable package (src/) and the standalone script (scripts/statusline.py), using the Sync Points table in CLAUDE.md as the contract
+tools: Read, Grep, Glob
+---
+You are a parity reviewer for the context-stats project. Given a diff or a list
+of changed files:
+
+- For every change to logic listed in the Sync Points table in CLAUDE.md, check
+  whether the mirrored side (package module or standalone function) needs the
+  same change.
+- Flag any edit to synced logic that touched only one side.
+- Do not run builds, tests, or linters — verification gates belong to the
+  invoking agent (see CLAUDE.md).
+
+Report each finding as `file:line`, the violated sync pair, and a one-line fix
+suggestion. End with `PARITY: CLEAN` when there are no violations.
+```
+
+### state-contract-reviewer
+
+```markdown
+---
+name: state-contract-reviewer
+description: Reviews changes to state persistence for compliance with the append-only CSV contract (15 fields, comma sanitization, rotation thresholds, session ID validation)
+tools: Read, Grep, Glob
+---
+You are a state-persistence reviewer for the context-stats project. Given a diff
+or a list of changed files:
+
+- Verify CSV writes preserve the 15-field layout in docs/CSV_FORMAT.md and that
+  `workspace_project_dir` has commas replaced with underscores before writing.
+- Verify append-only semantics and rotation at 10,000 lines keeping the most
+  recent 5,000.
+- Verify session IDs are rejected when containing `/`, `\`, `..`, or null bytes
+  before being used in paths.
+- Flag any newly introduced network call — this project makes none by design.
+
+Report each finding as `file:line` with a concrete fix. End with
+`CONTRACT: CLEAN` when compliant.
+```
+
+## Notes
+
+- Both subagents are read-only reviewers; keep the minimum tool surface and add
+  write or Bash tools only when extending them deliberately.
+- Keep each definition single-domain — split it rather than grow it.
+
+## Token Efficiency
+
+- Never re-read files you just wrote or edited. You know the contents.
+- Never re-run commands to "verify" unless the outcome was uncertain.
+- Don't echo back large blocks of code or file contents unless asked.
+- Batch related edits into single operations. Don't make 5 edits when 1 handles it.
+- Skip confirmations like "I'll continue..." Just do it.
+- If a task needs 1 tool call, don't use 3. Plan before acting.
+- Do not summarize what you just did unless the result is ambiguous or you need additional input.


### PR DESCRIPTION
Closes #114

## Summary

Creates root `AGENTS.md` via `/agent-config create` conventions, scoped strictly
to subagent definitions: two read-only, single-domain reviewer subagents that
guard this repo's two structural contracts. Build/test commands and verification
gates remain solely in `CLAUDE.md` and `docs/DEVELOPMENT.md` (Pre.1) — linked,
never duplicated. Implements Task Pre.3 of the modernization plan (#106).

## Approach

Minimal option — one new file following agent-config AGENTS.md guidelines
(frontmatter `name`/`description`/`tools`, minimum tool surface, single-domain
focus), plus the mandated token-efficiency block. Subagents target the two
highest-risk change patterns in this codebase:

1. `sync-point-reviewer` — parity between `src/claude_statusline/` and the
   standalone `scripts/statusline.py` (Sync Points table in CLAUDE.md).
2. `state-contract-reviewer` — append-only CSV state contract (15 fields,
   comma sanitization, rotation, session-ID validation).

## Decision Record

- **Root cause:** `AGENTS.md` absent from repo root; modernization plan Pre.3 requires an agent-facing subagent-definition file distinct from CLAUDE.md project context.
- **Options considered:** Option 1 — minimal root AGENTS.md with 2 focused read-only reviewers; Option 2 — comprehensive AGENTS.md duplicating CLAUDE.md build/test context plus reviewers; Option 3 — `.claude/agents/*.md` files instead of root AGENTS.md
- **Options rejected:** Option 2 — violates issue AC#2 (no duplicated build/test instructions) and agent-config anti-patterns; Option 3 — issue explicitly targets root `AGENTS.md` via `/agent-config`
- **Selected option:** Option 1 — minimal root AGENTS.md scoped to subagent definitions
- **Residual risk:** none identified
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `issue-114-task-pre-3-create-agents-md-via @ f23acbd` (2026-08-22)

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | New — subagent definitions (`sync-point-reviewer`, `state-contract-reviewer`) + token-efficiency block; cross-references CLAUDE.md/docs instead of duplicating them |

## Test Results

- Unit tests: 616 passed
- Integration tests: n/a (docs-only change)
- E2e tests: n/a (docs-only change)
- Build: n/a (docs-only change)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `AGENTS.md` exists at the repo root, created via `/agent-config` | pass | `AGENTS.md` at repo root; follows agent-config create conventions (frontmatter definitions with required name/description/tools, token-efficiency block, 71 lines < 80 budget) |
| `AGENTS.md` contains no duplicated build/test instructions (those live in `CLAUDE.md`/Pre.1 notes only) | pass | File contains zero shell commands; `CLAUDE.md` and `docs/DEVELOPMENT.md` referenced by link only |

<!-- gitissue:qa v1 head=f23acbd3b53503054ebd69e45fe112a4adf8fda2 profile=light cycles=1 review=clean tests=616@f23acbd3b53503054ebd69e45fe112a4adf8fda2 ui=none -->
