### PR TITLE
test(ci): enforce coverage floor via shared pytest config (#117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,13 @@ jobs:
           # C extension tracer and Windows process shutdown. We capture the result,
           # and on Windows only, treat exit code 1 as success when no tests failed.
           set +e
-          pytest tests/python/ -v --cov=scripts --cov=src --cov-report=xml --cov-report=term 2>&1 | tee pytest_output.txt
+          # Coverage floor (--cov-fail-under=73) is inherited from
+          # pyproject.toml [tool.pytest.ini_options] addopts (issue #117), so
+          # the measured scope here must match the pinned scope:
+          # src/claude_statusline (73.78% precise on main). The previous
+          # scripts+src scope measures 66% and would trip that floor on every
+          # matrix leg.
+          pytest tests/python/ -v --cov=src/claude_statusline --cov-report=xml --cov-report=term 2>&1 | tee pytest_output.txt
           PYTEST_EXIT=${PIPESTATUS[0]}
           set -e
           if [ "$RUNNER_OS" = "Windows" ] && [ "$PYTEST_EXIT" -eq 1 ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ State files are append-only CSV at `~/.claude/statusline/statusline.<session_id>
 # Python tests (canonical — matches docs/DEVELOPMENT.md agent setup notes)
 source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider
 
-# Coverage (measures src/claude_statusline per [tool.coverage.run])
-pytest tests/python/ -q -p no:cacheprovider --cov=claude_statusline --cov-report=term
+# Coverage (enforces the --cov-fail-under=73 floor from pyproject.toml addopts)
+pytest tests/python/ -q -p no:cacheprovider --cov=src/claude_statusline --cov-report=term
 ```
 
 ## Verification Gates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,8 @@ bats tests/bash/*.bats
 # Python tests
 pytest tests/python/ -v
 
-# Python tests with coverage
-pytest tests/python/ -v --cov=scripts --cov-report=html
+# Python tests with coverage (enforces the --cov-fail-under=73 floor from pyproject.toml)
+pytest tests/python/ -v --cov=src/claude_statusline --cov-report=term
 ```
 
 ## Code Quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ testpaths = ["tests/python"]
 # Raised toward the 94% M3 target by Tasks 4.6 and 5.7 of the modernization
 # plan. Inert unless coverage is requested (--cov); every invocation that does
 # request it inherits the enforcement.
-addopts = "-v --tb=short --cov-fail-under=73"
+addopts = "-v --tb=short --cov-fail-under=99 # PROBE: unreachable floor to prove the CI gate trips (reverted next commit)"
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,9 +129,7 @@ testpaths = ["tests/python"]
 # Raised toward the 94% M3 target by Tasks 4.6 and 5.7 of the modernization
 # plan. Inert unless coverage is requested (--cov); every invocation that does
 # request it inherits the enforcement.
-# PROBE (reverted in the following commit): unreachable floor isolates the
-# coverage gate as the sole failure source while all tests stay green.
-addopts = "-v --tb=short --cov-fail-under=99"
+addopts = "-v --tb=short --cov-fail-under=99 # PROBE: unreachable floor to prove the CI gate trips (reverted next commit)"
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,9 @@ testpaths = ["tests/python"]
 # Raised toward the 94% M3 target by Tasks 4.6 and 5.7 of the modernization
 # plan. Inert unless coverage is requested (--cov); every invocation that does
 # request it inherits the enforcement.
-addopts = "-v --tb=short --cov-fail-under=99 # PROBE: unreachable floor to prove the CI gate trips (reverted next commit)"
+# PROBE (reverted in the following commit): unreachable floor isolates the
+# coverage gate as the sole failure source while all tests stay green.
+addopts = "-v --tb=short --cov-fail-under=99"
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ testpaths = ["tests/python"]
 # Raised toward the 94% M3 target by Tasks 4.6 and 5.7 of the modernization
 # plan. Inert unless coverage is requested (--cov); every invocation that does
 # request it inherits the enforcement.
-addopts = "-v --tb=short --cov-fail-under=99 # PROBE: unreachable floor to prove the CI gate trips (reverted next commit)"
+addopts = "-v --tb=short --cov-fail-under=73"
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,15 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]
-addopts = "-v --tb=short"
+# Coverage floor (issue #117, F-TEST-006): measured over src/claude_statusline
+# on main — 2750 statements, 721 missed, identical across the Python 3.9-3.12
+# CI matrix legs and stable between interpreters locally. The precise total is
+# 73.78%, and coverage compares fail-under against the unrounded value, so a
+# literal 74 would fail on main itself; 73 is today's measured-value floor.
+# Raised toward the 94% M3 target by Tasks 4.6 and 5.7 of the modernization
+# plan. Inert unless coverage is requested (--cov); every invocation that does
+# request it inherits the enforcement.
+addopts = "-v --tb=short --cov-fail-under=73"
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 


### PR DESCRIPTION
Closes #117

## Summary

Task 0.3 of the modernization plan (F-TEST-006): coverage was measured everywhere but enforced nowhere. A `--cov-fail-under` floor is now pinned in `pyproject.toml [tool.pytest.ini_options] addopts`, so every invocation that requests coverage — local runs and all CI matrix legs — inherits enforcement and regressions fail immediately.

## Approach

Single enforcement point in shared pytest config, with CI aligned to the enforced scope:

1. `addopts = "-v --tb=short --cov-fail-under=73"` in `pyproject.toml`.
2. `.github/workflows/ci.yml` measures `--cov=src/claude_statusline` (the pinned scope) instead of the previous `--cov=scripts --cov=src`.

The scope alignment is load-bearing: the old CI scope measures **66%** and would trip any floor near today's package value on all 12 matrix legs; the package scope is what the issue pins and what Tasks 4.6/5.7 will raise toward the 94% M3 target.

## Decision Record

- **Root cause:** No `--cov-fail-under` existed anywhere (`pyproject.toml`, `pytest.ini`, `tox.ini`, workflows); CI reported coverage via Codecov but never gated on it.
- **Options considered:** Option 1 — pin only `--cov-fail-under` in shared addopts at the issue's literal 74; Option 2 — keep CI's broad scripts+src scope and lower the shared floor to 66; Option 3 — pin the measured-value floor in shared addopts and align CI's measured scope to the enforced package scope
- **Options rejected:** Option 1 — a literal 74 fails on main itself: coverage compares fail-under against the unrounded total, which is precisely **73.78%** (verified empirically: `FAIL Required test coverage of 74% not reached. Total coverage: 73.78%`); Option 2 — a 66 floor contradicts the issue's intent, leaves ~8 points of regression headroom, and would not go red when coverage drops below the measured package value
- **Selected option:** Option 3 — floor 73 (today's measured-value floor that actually holds) + CI scope alignment, documented inline at both sites
- **Residual risk:** The Windows matrix leg whitewashes a bare exit code 1 when no test failed (pre-existing workaround for the pytest-cov/Windows shutdown bug), so on Windows only, a pure coverage-gate trip is reported as success by that one job; ubuntu/macos legs and the `ci-success` aggregate still gate, so CI goes red overall. Floor stability across the matrix de-risked before pinning: statement counts are identical on Python 3.11 and 3.14 locally (2750 stmts / 721 missed → 73.78%), so the exact integer holds on all legs.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `issue-117-task-0-3-enforce-a-coverage-floor @ fb704fa` (2026-08-22)

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `--cov-fail-under=73` added to `[tool.pytest.ini_options] addopts` with rationale comment (measured value, unrounded-comparison note, Task 4.6/5.7 raise path) |
| `.github/workflows/ci.yml` | pytest step measures `--cov=src/claude_statusline` to match the enforced scope; comment documents why |
| `CONTRIBUTING.md` | documented coverage command updated to the enforced scope/floor |
| `CLAUDE.md` | canonical coverage command updated to the enforced scope/floor |

## Test Results

- Unit tests: 616 passed
- Integration tests: unchanged (no code changes)
- E2e tests: unchanged (no code changes)
- Build: n/a (config-only change)
- QA cycles: 1

Verification runs (all exit 0): issue verify command (`--cov=src/claude_statusline --cov-report=term --cov-fail-under=73`), CI-style invocation, bare pytest (release.yml style — flag confirmed inert without `--cov`, so release runs are unaffected), on Python 3.14 and 3.11. Negative control: `--cov-fail-under=74` reproduces red on main's tree.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `pytest --cov=src/claude_statusline --cov-report=term --cov-fail-under=74` passes in CI and locally | pass (floor = 73) | The criterion's literal 74 cannot pass on main: unrounded coverage is 73.78%, and coverage compares fail-under unrounded (negative control run shows `FAIL Required test coverage of 74% not reached`). Per caller guidance the floor is pinned to the measured integer that holds — 73 — documented in pyproject.toml:122-131. The enforced command passes locally on two interpreters and inherits into every CI leg |
| Deliberately dropping coverage below the floor makes CI red — revert the probe | pass | Pushed probe commit on this branch spikes the inherited floor to an unreachable value; the `Python Tests` workflow job fails at exactly the coverage gate (`FAIL Required test coverage of 99% not reached`) while all 616 tests stay green, then is reverted — isolating the gate as the failure source. Local companion check: commenting out one tested call site also turns pytest red |

<!-- gitissue:qa v1 head=07e369bb27ee119946154760e2227f78336fc7f7 profile=light cycles=1 review=clean tests=616@07e369bb27ee119946154760e2227f78336fc7f7 ui=none -->
