### PR TITLE
chore(ci): add pip-audit vulnerability scanning (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             requirements-dev.constraints.txt
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
+        run: python -m pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
 
       - name: Run Ruff (linting)
         run: ruff check .
@@ -66,8 +66,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
-          pip install -e .
+          python -m pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
+          python -m pip install -e .
 
       - name: Run pytest with coverage
         shell: bash
@@ -254,7 +254,7 @@ jobs:
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
+        run: python -m pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
 
       - name: Run pre-commit hooks on all files
         # Hooks never execute in CI (F-CI-004), so hook drift goes unnoticed.
@@ -285,7 +285,7 @@ jobs:
             requirements-dev.constraints.txt
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
+        run: python -m pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
 
       - name: Audit locked environment with pip-audit
         # Fails on any known advisory not explicitly ignored in the script.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,11 +266,39 @@ jobs:
         run: pre-commit run --all-files
 
   # ============================================
+  # DEPENDENCY VULNERABILITY SCAN (F-DEP-008)
+  # ============================================
+  dependency-scan:
+    name: Dependency Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-dev.txt
+            requirements-dev.constraints.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
+
+      - name: Audit locked environment with pip-audit
+        # Fails on any known advisory not explicitly ignored in the script.
+        # Every ignored advisory has a filed ticket (#161); see
+        # docs/DEVELOPMENT.md ("Security auditing").
+        run: bash scripts/pip-audit-locked.sh
+
+  # ============================================
   # FINAL STATUS CHECK
   # ============================================
   ci-success:
     name: CI Success
-    needs: [python-lint, python-test, integration-test, e2e-install-pip, e2e-exec, pre-commit]
+    needs: [python-lint, python-test, integration-test, e2e-install-pip, e2e-exec, pre-commit, dependency-scan]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -281,7 +309,8 @@ jobs:
              [[ "${{ needs.integration-test.result }}" != "success" ]] || \
              [[ "${{ needs.e2e-install-pip.result }}" != "success" ]] || \
              [[ "${{ needs.e2e-exec.result }}" != "success" ]] || \
-             [[ "${{ needs.pre-commit.result }}" != "success" ]]; then
+             [[ "${{ needs.pre-commit.result }}" != "success" ]] || \
+             [[ "${{ needs.dependency-scan.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,37 @@
+name: Security Audit
+
+# Weekly vulnerability scan of the locked dev environments (F-DEP-008).
+# The same audit also gates every push/PR via the dependency-scan job in
+# ci.yml; this schedule catches advisories published after the last push.
+
+on:
+  schedule:
+    # Every Monday at 06:23 UTC
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  dependency-scan:
+    name: Weekly pip-audit (locked dev environment)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements-dev.txt
+            requirements-dev.constraints.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
+
+      - name: Audit locked environment with pip-audit
+        # Fails on any known advisory not explicitly ignored in the script.
+        # Every ignored advisory has a filed ticket (#161); see
+        # docs/DEVELOPMENT.md ("Security auditing").
+        run: bash scripts/pip-audit-locked.sh

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -28,7 +28,7 @@ jobs:
             requirements-dev.constraints.txt
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
+        run: python -m pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
 
       - name: Audit locked environment with pip-audit
         # Fails on any known advisory not explicitly ignored in the script.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -69,6 +69,20 @@ pre-commit install
 
 `requirements-dev.constraints.txt` pins every dev requirement (and its transitive dependencies) to exact versions so local installs and CI are reproducible; it is consumed via `pip install -r requirements-dev.txt -c requirements-dev.constraints.txt` in every CI job that installs dev dependencies (`python-lint`, `python-test`, and the release workflow's test job). To regenerate it after editing `requirements-dev.txt`, resolve at the **Python 3.9 floor** — the oldest version CI supports — so the pins stay installable across the whole 3.9–3.12 matrix: run `pip download --dest /tmp/wheels --python-version 3.9 --only-binary=:all: -r requirements-dev.txt`, read the exact resolved versions from the downloaded wheel filenames, and write them into the constraints file as `name==version` lines (canonical PyPI names, alphabetically sorted). Then verify before committing: re-run that same download command with `-c requirements-dev.constraints.txt` for each matrix Python (`3.9`, `3.10`, `3.11`, `3.12`) — all four must resolve without conflicts — and run the recorded test command in a clean venv installed with the constraints.
 
+### Security auditing
+
+The locked dev environment is scanned for known vulnerabilities with `pip-audit` (F-DEP-008). The scanner itself is pinned in `requirements-dev.constraints.txt` like every other dev dependency. Run it locally from an activated venv:
+
+```bash
+pip-audit -r requirements-dev.constraints.txt --progress-spinner off
+# or, equivalently, with the ticketed exceptions applied:
+bash scripts/pip-audit-locked.sh
+```
+
+CI runs the same audit on every push/PR (`dependency-scan` job in `.github/workflows/ci.yml`) and weekly ([`.github/workflows/security-audit.yml`](../.github/workflows/security-audit.yml)). The gate fails on **any** known advisory — stricter than the High/Critical requirement.
+
+**Exception policy:** an advisory may only be silenced with a filed ticket. Add one `--ignore-vuln <ID>` line per advisory to `scripts/pip-audit-locked.sh`, reference the ticket in that script's header comment, and note it in `requirements-dev.constraints.txt`. Current exceptions are tracked in [#161](https://github.com/luongnv89/context-stats/issues/161): every fix version requires Python >= 3.10 directly, or conflicts across the CI matrix with the Python 3.9-floor pins, so they become actionable when the minimum supported Python rises to 3.10+ — bump the affected pins and delete the matching flags then. When a **new** advisory appears: first try bumping the pin within what resolves at the 3.9 floor; only if no fix installs, file a ticket and add the flag.
+
 ## Project Layout
 
 ```

--- a/requirements-dev.constraints.txt
+++ b/requirements-dev.constraints.txt
@@ -5,25 +5,57 @@
 # version CI supports), so every pin installs across the full CI matrix.
 # Regeneration is documented in docs/DEVELOPMENT.md ("Regenerating the
 # dev-dependency constraints file").
+#
+# Security exceptions: the advisory IDs ignored by scripts/pip-audit-
+# locked.sh (12 findings across msgpack, filelock, pip, pytest, requests,
+# urllib3 and virtualenv) currently have no fix installable across the
+# whole CI matrix — every fix version requires Python >= 3.10 directly,
+# or conflicts across the matrix with the Python 3.9-floor pins. They are
+# silenced (with a filed ticket, #161) by the CI audit until the minimum
+# supported Python rises to 3.10+. See docs/DEVELOPMENT.md ("Security
+# auditing").
+boolean.py==5.0
+cachecontrol==0.14.3
+certifi==2026.7.22
 cfgv==3.4.0
+charset-normalizer==3.5.1
 coverage==7.10.7
+cyclonedx-python-lib==9.1.0
+defusedxml==0.7.1
 distlib==0.4.3
 filelock==3.19.1
 identify==2.6.15
+idna==3.19
 iniconfig==2.1.0
 librt==0.15.0
+license-expression==30.4.4
+markdown-it-py==3.0.0
+mdurl==0.1.2
+msgpack==1.1.2
 mypy==1.19.1
 mypy-extensions==1.1.0
 nodeenv==1.10.0
+packageurl-python==0.17.6
 packaging==26.3
 pathspec==1.1.1
+pip==26.0.1
+pip-api==0.0.34
+pip-audit==2.9.0
+pip-requirements-parser==32.0.1
 platformdirs==4.4.0
 pluggy==1.6.0
 pre-commit==4.3.0
+py-serializable==2.1.0
 pygments==2.21.0
+pyparsing==3.3.2
 pytest==8.4.2
 pytest-cov==7.1.0
 PyYAML==6.0.3
+requests==2.32.5
+rich==15.0.0
 ruff==0.16.4
+sortedcontainers==2.4.0
+toml==0.10.2
 typing-extensions==4.16.0
+urllib3==2.6.3
 virtualenv==20.35.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,6 @@ mypy>=1.7.0
 
 # Pre-commit hooks
 pre-commit>=3.6.0
+
+# Security auditing
+pip-audit>=2.7,<3

--- a/scripts/pip-audit-locked.sh
+++ b/scripts/pip-audit-locked.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Audit the locked dev environment for known vulnerabilities (F-DEP-008).
+#
+# Single source of truth for the audit command: run by CI (.github/workflows/
+# ci.yml and security-audit.yml) and safe to run locally from an activated
+# venv. Exits non-zero on any known advisory NOT listed below, so a new
+# High/Critical advisory fails the gate immediately.
+#
+# Every --ignore-vuln entry MUST reference a filed ticket (#161). All current
+# entries have fix versions requiring Python >= 3.10 (directly or via matrix
+# conflicts with the Python 3.9 floor pins) and MUST be revisited when the
+# minimum supported Python rises to 3.10+.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+exec pip-audit -r requirements-dev.constraints.txt --progress-spinner off \
+	--ignore-vuln PYSEC-2026-3625 \
+	--ignore-vuln PYSEC-2026-1375 \
+	--ignore-vuln PYSEC-2026-1374 \
+	--ignore-vuln PYSEC-2026-196 \
+	--ignore-vuln PYSEC-2026-2875 \
+	--ignore-vuln PYSEC-2026-2876 \
+	--ignore-vuln PYSEC-2026-3721 \
+	--ignore-vuln PYSEC-2026-1845 \
+	--ignore-vuln PYSEC-2026-2275 \
+	--ignore-vuln PYSEC-2026-142 \
+	--ignore-vuln PYSEC-2026-141 \
+	--ignore-vuln PYSEC-2026-2009


### PR DESCRIPTION
Closes #119

## Summary

Adds the project's first vulnerability scanning (F-DEP-008, modernization task 1.1): `pip-audit` is pinned into the locked dev environment, a `dependency-scan` CI job audits the locked constraints file on every push/PR, and a new weekly scheduled workflow runs the same audit. The gate fails on **any** known advisory — stricter than the High/Critical requirement — and is currently green with 12 findings silenced under filed ticket #161 (every fix version requires Python ≥ 3.10 or conflicts across the matrix with the Python 3.9-floor pins).

## Approach

Balanced option: keep the single lockfile contract (`requirements-dev.constraints.txt`, resolved at the Python 3.9 floor per docs/DEVELOPMENT.md) and put both the scanner and its exceptions inside it. A shared `scripts/pip-audit-locked.sh` holds the audit command once so the PR/push gate and the weekly schedule can never drift apart.

## Decision Record

- **Root cause:** no vulnerability scanning existed anywhere in dev or CI tooling (F-DEP-008); the locked environments could accumulate known advisories unnoticed.
- **Options considered:** Option 1 — minimal, invoke an unpinned pip-audit ad hoc in CI; Option 2 — pin pip-audit in the locked env with a shared audit script, CI gate job, and weekly scheduled workflow; Option 3 — comprehensive, add SARIF upload, a pre-commit audit hook, and raise the floor to Python ≥ 3.10.
- **Options rejected:** Option 1 — an unpinned scanner is non-reproducible and outside the repo's lockfile contract; Option 3 — scope creep beyond task 1.1, and dropping Python 3.9 belongs to a separate modernization task that owns the matrix.
- **Selected option:** Option 2
- **Residual risk:** 12 known advisories in dev-only tooling remain intentionally ignored under ticket [#161](https://github.com/luongnv89/context-stats/issues/161) — all are local attack surface (`AV:L`) and every fix requires Python ≥ 3.10 directly (filelock 3.20.1+, pip 26.1+, pytest 9.0.3, requests 2.33.0, urllib3 2.7.0, msgpack 1.2.1+) or conflicts across the matrix with the 3.9-floor pins (virtualenv 20.36.1 needs filelock≥3.20.1 on ≥3.10). The gate still fails on any advisory not in the ignore list; all ignores must be dropped when the floor rises.

Analyzed at: `issue-119-task-1-1-add-pip-audit @ fda966b` (2026-08-22)

## Changes

| File | Change |
|------|--------|
| `requirements-dev.txt` | Add `pip-audit>=2.7,<3` under a Security auditing section |
| `requirements-dev.constraints.txt` | Pin `pip-audit==2.9.0` (newest release installable on Python 3.9) plus its transitive dependencies, resolved at the 3.9 floor; document the ticketed security exceptions |
| `scripts/pip-audit-locked.sh` | New single source of truth for the audit command with one documented `--ignore-vuln` flag per ticketed advisory (#161) |
| `.github/workflows/ci.yml` | New `dependency-scan` job auditing the locked environment on push/PR; wired into the `ci-success` aggregate check |
| `.github/workflows/security-audit.yml` | New weekly scheduled scan (Mondays 06:23 UTC) plus manual `workflow_dispatch` |
| `docs/DEVELOPMENT.md` | Document local usage, gate semantics, and the exception policy (ticket required, revisit at floor bump) |

## Test Results

- Unit tests: 616 passed (`pytest tests/python/ -q -p no:cacheprovider`)
- Audit verification: `pip-audit -r requirements-dev.constraints.txt` reports exactly the 12 ticketed advisories and nothing else; `bash scripts/pip-audit-locked.sh` exits 0
- Constraints resolution verified per the documented procedure: `pip download --python-version {3.9,3.10,3.11,3.12} -c requirements-dev.constraints.txt` resolves without conflicts on all four matrix Pythons
- Gates: ruff check, ruff format, mypy, and pre-commit hooks (including shellcheck) all pass on changed files
- Integration/E2E: covered by the existing CI legs on clean runners
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| CI job runs `pip-audit` over the locked environments and fails on High/Critical advisories; currently green (or every finding has a filed ticket) | pass | `dependency-scan` job in `.github/workflows/ci.yml` (stricter: fails on any severity); green via `bash scripts/pip-audit-locked.sh` exit 0 with all 12 findings ticketed in #161 |
| Weekly scheduled workflow exists running the same audit | pass | `.github/workflows/security-audit.yml` cron `23 6 * * 1`, running the identical shared script |
| Test command of record passes at ≥ 616/616 | pass | 616 passed at `fda966b9ba979c57e09d47ca8abf70175e20f7e8` |

<!-- gitissue:qa v1 head=fda966b9ba979c57e09d47ca8abf70175e20f7e8 profile=full cycles=1 review=clean tests=616@fda966b9ba979c57e09d47ca8abf70175e20f7e8 ui=none -->
