### PR TITLE
fix(ci): env-indirect workflow_dispatch input in release.yml (#121)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,20 +28,24 @@ jobs:
 
       - name: Determine version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "$EVENT_NAME" == "push" ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            VERSION="${{ github.event.inputs.version }}"
+            VERSION="$DISPATCH_VERSION"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Release version: $VERSION"
 
       - name: Validate version format
+        env:
+          VERSION_TO_VALIDATE: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
-            echo "Invalid version format: $VERSION"
+          if ! [[ "$VERSION_TO_VALIDATE" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+            echo "Invalid version format: $VERSION_TO_VALIDATE"
             echo "Expected format: X.Y.Z or X.Y.Z-suffix"
             exit 1
           fi


### PR DESCRIPTION
Closes #121

## Summary

`workflow_dispatch` inputs were interpolated directly into bash `run:` blocks of `.github/workflows/release.yml` (a workflow holding `contents: write`) before any validation — GitHub expression expansion happens before bash parsing, so a crafted `version` input could execute arbitrary commands in the runner (F-CI-007). All event/input-derived values now reach the script as environment variables, and the pre-existing format gate rejects malformed versions before anything downstream consumes them.

## Approach

**Option 2 — env-indirection in validate job.** Values are passed through step-level `env:` mappings (`EVENT_NAME`, `DISPATCH_VERSION`, `VERSION_TO_VALIDATE`) and referenced as quoted shell variables, so they expand as data, never as script text. The two-step design (determine → validate) is preserved; no validation logic changed.

## Decision Record

- **Root cause:** `${{ github.event.inputs.version }}`, `${{ github.event_name }}`, and the derived `${{ steps.version.outputs.version }}` were expanded into the bash source of the "Determine version" and "Validate version format" steps before execution; a newline or `$(...)` payload in the dispatch input could break out of the quoting and run attacker script on a `contents: write` runner.
- **Options considered:** Option 1 — inline regex validation inside "Determine version"; Option 2 — env-indirection for all event/input-derived context, keeping the existing separate validation gate; Option 3 — replace bash steps with a composite action/`actions/github-script`.
- **Options rejected:** Option 1 — duplicates the format regex and leaves the same interpolation class in the validate step (`steps.*` output derived from user input); Option 3 — outsized churn for an S-sized hardening task.
- **Selected option:** Option 2 — env-indirection in validate job
- **Residual risk:** none identified — post-validation `needs.validate.outputs.version` uses in `create-release` are gated behind the format check failing the whole `validate` job.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `issue-121-task-1-3-fix-workflow-dispatch @ dae5c34` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | Route `github.event_name`, `github.event.inputs.version`, and `steps.version.outputs.version` through `env:` indirection; `run:` scripts reference quoted shell vars only |

## Test Results

- Unit tests: 616 passed (`pytest tests/python/ -q -p no:cacheprovider`)
- Integration tests: n/a (workflow-only change)
- E2e tests: live `workflow_dispatch` smoke — [run 32603762658 green](https://github.com/luongnv89/context-stats/actions/runs/32603762658) with benign input `version=0.0.0-smoke` on this branch's workflow file; throwaway release/tag deleted afterwards
- Build: YAML parse + injection-payload simulation pass (quoted payloads, newline payloads, empty input all rejected by the format gate)
- QA cycles: 1 (clean)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| No `${{ inputs.* }}` (or `${{ github.event.* }}`) interpolation remains inside `run:` blocks of `.github/workflows/release.yml`; actionlint-class check passes | pass | AST walk of parsed workflow: zero matches in all `run:` blocks; remaining `inputs.` reference is inside an `env:` mapping by design |
| A manual dispatch with a benign input still completes the release-dry path successfully | pass | https://github.com/luongnv89/context-stats/actions/runs/32603762658 (success @ 2f58baf, event=workflow_dispatch) |
| Test command of record passes at ≥ 616/616 | pass | 616 passed in 16.54s @ 2f58baf5491a515f734b9d8f1df1b19ddc587ceb |

<!-- gitissue:qa v1 head=2f58baf5491a515f734b9d8f1df1b19ddc587ceb profile=light cycles=1 review=clean tests=616@2f58baf5491a515f734b9d8f1df1b19ddc587ceb ui=none -->
