### PR TITLE
chore(deps): batch-update stale pre-commit hook revs (#122)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_language_version:
 repos:
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-json
@@ -26,7 +26,7 @@ repos:
 
   # ShellCheck for bash scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.6
+    rev: v0.11.0.1-1
     hooks:
       - id: shellcheck
         args: ['--severity=warning']
@@ -65,7 +65,7 @@ repos:
 
   # Markdown lint
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.39.0
+    rev: v0.49.1
     hooks:
       - id: markdownlint
         args: ['--fix', '--disable', 'MD013', 'MD024', 'MD033', 'MD040', 'MD041', '--']

--- a/docs/example-report-30days.md
+++ b/docs/example-report-30days.md
@@ -69,20 +69,22 @@ pie title Model Cost Distribution
      - m5b1a674... (Unknown): 0% cache hit
 
 2. **Model efficiency by family**
-   | Model | Sessions | $/1k tokens |
-   |-------|----------|-------------|
-   | haiku | 29 | $0.022 |
-   | opus | 241 | $0.040 |
-   | sonnet | 42 | $0.037 |
+
+   | Model  | Sessions | $/1k tokens |
+   | ------ | -------- | ----------- |
+   | haiku  | 29       | $0.022      |
+   | opus   | 241      | $0.040      |
+   | sonnet | 42       | $0.037      |
 
 3. **High-spend projects to review**
-   | Project | Sessions | Cost | Cache Hit % |
-   |---------|----------|------|-------------|
-   | project-alpha | 28 | $412.80 | 12% |
-   | project-beta | 41 | $318.44 | 44% |
-   | project-gamma | 35 | $264.17 | 38% |
-   | project-delta | 27 | $198.53 | 49% |
-   | project-epsilon | 22 | $187.62 | 31% |
+
+   | Project         | Sessions | Cost    | Cache Hit % |
+   | --------------- | -------- | ------- | ----------- |
+   | project-alpha   | 28       | $412.80 | 12%         |
+   | project-beta    | 41       | $318.44 | 44%         |
+   | project-gamma   | 35       | $264.17 | 38%         |
+   | project-delta   | 27       | $198.53 | 49%         |
+   | project-epsilon | 22       | $187.62 | 31%         |
 
 ```mermaid
 xychart-beta

--- a/openspec/changes/archive/2026-03-12-csv-format-doc-comma-guard/specs/csv-format-spec/spec.md
+++ b/openspec/changes/archive/2026-03-12-csv-format-doc-comma-guard/specs/csv-format-spec/spec.md
@@ -19,7 +19,7 @@ The project SHALL have a `docs/CSV_FORMAT.md` file that documents the state file
 The CSV state file format SHALL consist of exactly 14 comma-separated fields per line, in the following fixed order:
 
 | Index | Field | Type |
-|-------|-------|------|
+| ------- | ------- | ------ |
 | 0 | timestamp | integer (unix seconds) |
 | 1 | total_input_tokens | integer |
 | 2 | total_output_tokens | integer |

--- a/openspec/specs/csv-format-spec/spec.md
+++ b/openspec/specs/csv-format-spec/spec.md
@@ -19,7 +19,7 @@ The project SHALL have a `docs/CSV_FORMAT.md` file that documents the state file
 The CSV state file format SHALL consist of exactly 14 comma-separated fields per line, in the following fixed order:
 
 | Index | Field | Type |
-|-------|-------|------|
+| ------- | ------- | ------ |
 | 0 | timestamp | integer (unix seconds) |
 | 1 | total_input_tokens | integer |
 | 2 | total_output_tokens | integer |


### PR DESCRIPTION
Closes #122

## Summary

Batch-update the stale pre-commit hook revs called out by F-DEP-003/005/006/007: markdownlint-cli v0.39.0 → v0.49.1, shellcheck-py v0.9.0.6 → v0.11.0.1-1, pre-commit-hooks v4.5.0 → v6.0.0, applied in the plan's churn order (markdownlint first, ruff last). ruff-pre-commit already sits at its latest release (v0.16.4), which is exactly the `requirements-dev.constraints.txt` ruff pin, so hook and venv/CI ruff agree on major.minor and no bump is needed there.

## Approach

Option B — targeted rev bumps plus empirical autofix-churn triage: mirror CI (`SKIP=e2e-install-tests pre-commit run --all-files`), let the newer hooks autofix what they can, converge formatter disagreement rather than weakening any hook args, then confirm behavior preservation with the canonical pytest suite.

## Decision Record

- **Root cause:** `.pre-commit-config.yaml` pinned revs years stale relative to upstream releases (F-DEP-003/005/006/007), so local/CI hooks drifted from current linter behavior.
- **Options considered:** Option 1 — bump only verbatim, keep all args; Option 2 — targeted bumps + empirical churn triage + convergence between prettier/markdownlint; Option 3 — also bump mirrors-eslint/mirrors-prettier and restructure config
- **Options rejected:** Option 1 — leaves new-rule churn untriaged and risks a red `--all-files`; Option 3 — outside this issue's four-repo scope (eslint/prettier are not in the F-DEP list)
- **Selected option:** Option 2 — targeted bumps + empirical churn triage
- **Residual risk:** shellcheck-py publishes tags rather than GitHub Releases; `v0.11.0.1-1` is the newest maintained tag (includes the zsh-exclusion fix) and passes clean under existing `--severity=warning` args
- **Design-confirm:** auto-selected Option 2 (complexity: medium)

Analyzed at: `issue-122-task-1-4-batch-update-stale-pre-commit @ 770cabf` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `.pre-commit-config.yaml` | Rev bumps: markdownlint-cli v0.39.0→v0.49.1, shellcheck-py v0.9.0.6→v0.11.0.1-1, pre-commit-hooks v4.5.0→v6.0.0; ruff-pre-commit left at v0.16.4 with constraints-alignment comment intact |
| `docs/example-report-30days.md` | markdownlint v0.49.1 autofixes (blank lines around tables); prettier canonicalized tables (aligned cells) — cosmetic only |
| `openspec/specs/csv-format-spec/spec.md` | Same table autofixes — cosmetic only |
| `openspec/changes/archive/.../csv-format-spec/spec.md` | Same table autofixes (archived change spec) — cosmetic only |

## Test Results

- Unit tests: 616 passed (`pytest tests/python/ -q -p no:cacheprovider`, re-run at HEAD 3e79255)
- Integration tests: covered by the suite above
- E2e tests: unchanged (local `e2e-install-tests` hook excluded via CI's SKIP convention; dedicated e2e jobs cover it)
- Build: n/a — no source changes
- QA cycles: 1 (clean on first cycle; ceiling 2)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `.pre-commit-config.yaml` revs match latest releases of all four hook repos; `pre-commit run --all-files` green | pass | Verified against GitHub API 2026-08-23: pre-commit-hooks v6.0.0, markdownlint-cli v0.49.1, ruff-pre-commit v0.16.4 (all latest Releases); shellcheck-py v0.11.0.1-1 (newest tag — repo publishes no Release objects); full run green in three consecutive passes, 16 hooks Passed / 0 Failed |
| Hook ruff version agrees with venv/CI ruff major.minor (no divergent rulesets) | pass | Hook rev v0.16.4 == `requirements-dev.constraints.txt` `ruff==0.16.4`; alignment comment intact at `.pre-commit-config.yaml:36-38` |
| Test command of record passes at ≥ 616/616 (autofixes did not change behavior) | pass | 616 passed at HEAD 3e79255 after autofixes; diff touches only hook rev strings and markdown table formatting |

<!-- gitissue:qa v1 head=3e792556d3cc03ebba540e7256277cde7a2718ad profile=full cycles=1 review=clean tests=616@3e792556d3cc03ebba540e7256277cde7a2718ad ui=none:skipped@3e792556d3cc03ebba540e7256277cde7a2718ad -->
