### PR TITLE
chore(deps): pin actions/checkout to v7 sha (#123)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -53,7 +53,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -118,7 +118,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -148,7 +148,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -186,7 +186,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -273,7 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Closes #123

## Summary

All 11 `actions/checkout` usages across the three GitHub Actions workflows (ci.yml ×7, release.yml ×3, security-audit.yml ×1) move from the floating major tag `@v4` (F-DEP-004, modernization task 1.5) to the full-length commit SHA that upstream tag `v7` resolves to (`3d3c42e5aac5ba805825da76410c181273ba90b1`), each carrying a `# v7` version comment.

## Approach

`sha-pin-minimal` — resolve `refs/tags/v7` upstream via `git ls-remote https://github.com/actions/checkout refs/tags/v7`, then mechanically substitute every `uses: actions/checkout@v4` with the full-length SHA pin plus version comment. No workflow logic, inputs, or job structure changed.

## Decision Record

- **Root cause:** every checkout step was pinned only to the floating major tag `@v4`, so action code could shift underneath CI on each upstream v4.x release — an unauditable supply-chain surface (finding F-DEP-004).
- **Options considered:** Option 1 — bump tag to `@v7`; Option 2 — pin full-length v7 SHA + version comment; Option 3 — SHA-pin every third-party action in all workflows
- **Options rejected:** Option 1 — still a floating tag, fails AC1's full-length-SHA requirement; Option 3 — scope creep beyond task 1.5 ("one major per task"); other actions belong to separate plan tasks
- **Selected option:** Option 2 — sha-pin-minimal
- **Residual risk:** future checkout major bumps require a manual SHA refresh (accepted; owned by the modernization plan tracking issue)
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `issue-123-task-1-5-bump-actions-checkout-v4 @ 4014f4e` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | 7× `actions/checkout@v4` → `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7` |
| `.github/workflows/release.yml` | 3× same substitution |
| `.github/workflows/security-audit.yml` | 1× same substitution |

## Test Results

- Unit tests: 616 passed (`source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider` on branch HEAD `dd49384`)
- Integration tests: covered by the CI integration-test matrix legs (this PR's run)
- E2e tests: covered by the CI e2e jobs (this PR's run)
- Build: passed (YAML parse validation on all three workflows; pre-commit-compatible diff)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Every `actions/checkout` usage pinned to a full-length SHA tagged v7 (or documented v7 tag) | pass | `grep -A1 "uses: actions/checkout" .github/workflows/*.yml` → 11/11 usages at `3d3c42e5aac5ba805825da76410c181273ba90b1 # v7`; zero non-pinned refs remain (`git ls-remote … refs/tags/v7` confirms the SHA↔tag binding) |
| Both workflows green on a scratch branch after the bump (recorded test command ≥ 616/616 on all legs) | pass | CI run 32606352912 on this branch: conclusion `success`, all 28 jobs green incl. all 12 Python Tests legs and CI Success gate — https://github.com/luongnv89/context-stats/actions/runs/32606352912 ; local leg recorded 616/616 green at HEAD `dd49384` |

<!-- gitissue:qa v1 head=dd493843d3a1a485b2e8dbb1a50c74a62362b329 profile=light cycles=1 review=clean tests=616@dd493843d3a1a485b2e8dbb1a50c74a62362b329 ui=none -->
