### PR TITLE
chore(deps): pin actions/setup-python to v7 sha (#124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
 
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
 
@@ -239,7 +239,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -276,7 +276,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.11'
           cache: 'pip'


### PR DESCRIPTION
Closes #124

## Summary

Pins `actions/setup-python` to the full commit SHA of tag `v7`
(`5fda3b95a4ea91299a34e894583c3862153e4b97`) in every workflow, completing
task 1.6 of the modernization plan and closing finding **F-DEP-004** for this
action — the identical treatment applied to `actions/checkout` in #123/#166.
All 9 usage sites are updated; no behavioral inputs change.

## Approach

SHA-pin setup-python v7 across all workflows — replace every
`uses: actions/setup-python@v5` with
`uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7`.
The ref was resolved from the source repo (`git ls-remote
https://github.com/actions/setup-python refs/tags/v7`); the tag is lightweight,
so the listed object is the commit itself. Release notes were checked for
breaking changes: v7 removes only the unused `pip-install` input (verified
absent here); the v6 node24 / runner >= v2.327.1 requirement is satisfied by
GitHub-hosted runners.

## Decision Record

- **Root cause:** mutable tag references (`@v5`) allow upstream tag movement —
  a supply-chain exposure tracked as F-DEP-004; workflow-level dependency
  pinning requires immutable SHAs plus a human-readable version comment.
- **Options considered:** Option 1 — bump to bare `@v7` tag; Option 2 — SHA-pin
  v7 (`# v7` comment) across all workflows; Option 3 — also SHA-pin remaining
  third-party actions (`codecov/codecov-action@v4`, `actions/cache@v4`).
- **Options rejected:** Option 1 — defeats F-DEP-004's tamper-evidence goal;
  Option 3 — out of task 1.6 scope, covered by later plan items.
- **Selected option:** Option 2 — SHA-pin setup-python v7 across all workflows
- **Residual risk:** none identified beyond CI confirmation of the full matrix,
  provided by this PR's checks run.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped,
  QA capped at 1 cycle

Analyzed at: `issue-124-task-1-6-bump-actions-setup-python @ 2a99eda` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | 7 `setup-python` usages pinned to v7 SHA |
| `.github/workflows/release.yml` | 1 `setup-python` usage pinned to v7 SHA |
| `.github/workflows/security-audit.yml` | 1 `setup-python` usage pinned to v7 SHA |

## Test Results

- Unit tests: 616 passed (recorded command: `source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider`)
- Integration tests: exercised by CI matrix legs (`integration-test`: ubuntu/macos)
- E2e tests: exercised by CI matrix legs (`python-test`: 3 OS x Py 3.9-3.12; `e2e-install-pip`: 2 OS x Py 3.9-3.12; `e2e-exec`)
- Build: workflow YAML validated (`yaml.safe_load`) on all three files
- QA cycles: 1 (clean)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `actions/setup-python` pinned to v7 (SHA-pinned) | pass | All 9 usages now `@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7` — `.github/workflows/ci.yml:25` and 6 more, `.github/workflows/release.yml:62`, `.github/workflows/security-audit.yml:22`; zero unpinned refs remain (`grep 'setup-python@v'` empty); SHA verified against `refs/tags/v7` |
| Matrix jobs on all supported Pythons still provision correctly | pass | Recorded test command passes 616/616 locally (Py 3.11); full-matrix provisioning (ubuntu/macos/windows x Python 3.9/3.10/3.11/3.12 + e2e legs) proven by this PR's green CI run covering every leg |

<!-- gitissue:qa v1 head=2a99edad24335b44a535d0c4c9678715cce37d86 profile=light cycles=1 review=clean tests=616@2a99edad24335b44a535d0c4c9678715cce37d86 ui=none -->
