### PR TITLE
chore(ci): drop best-effort codecov upload for local coverage gate (#125)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,10 @@ jobs:
           fi
           exit $PYTEST_EXIT
 
-      - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.xml
-          flags: python
-          fail_ci_if_error: false
+      # No Codecov upload (#125, F-DEP-004 / F-CI-008): the action was two
+      # majors behind and uploaded best-effort with no token, so it never gave
+      # a reliable signal. Coverage enforcement happens locally instead via
+      # --cov-fail-under=73 in pyproject.toml addopts on every matrix leg.
 
   # ============================================
   # INTEGRATION TESTS


### PR DESCRIPTION
Closes #125

## Summary

Removes the best-effort Codecov upload step from CI. The codecov-action step was two majors behind (v4), uploaded with no token, and set `fail_ci_if_error: false`, so it never produced a reliable coverage signal despite the matrix paying the `--cov` cost on every leg (F-DEP-004, F-CI-008). Coverage enforcement already happens locally on every leg via `--cov-fail-under=73` in `pyproject.toml` addopts (Task 0.3).

## Approach

**Remove the upload step; rely on the local coverage gate.** The issue offers two acceptable end-states. Bumping to v7 SHA-pinned with `token: ${{ secrets.CODECOV_TOKEN }}` and `fail_ci_if_error: true` was rejected because no CODECOV_TOKEN secret exists on this repo (`gh secret list` is empty) and none could be configured by this run — every CI run would go red on a failing upload. Keeping a tokenless best-effort upload would preserve exactly the unreliable signal F-CI-008 flags. Removal makes CI genuinely green while keeping the enforcement signal.

## Decision Record

- **Root cause:** the Codecov upload was added as best-effort decoration: unpinned major, no token, `fail_ci_if_error: false`. Its failure modes were invisible by design, so it provided no dependable coverage reporting despite per-leg overhead.
- **Options considered:** Option 1 — bump codecov-action to v7 SHA-pinned + CODECOV_TOKEN secret + `fail_ci_if_error: true`; Option 2 — remove the upload step entirely and rely on the local `--cov-fail-under=73` floor from Task 0.3
- **Options rejected:** Option 1 — requires a CODECOV_TOKEN secret that does not exist on this repository and cannot be invented here; uploads would fail red on every CI run once `fail_ci_if_error: true`
- **Selected option:** Option 2 — remove the upload step entirely with rationale recorded (in ci.yml comment and this record)
- **Residual risk:** coverage results are no longer aggregated/reported on codecov.io; enforcement is unaffected (`--cov-fail-under=73` fails any leg below the floor). If a token is later configured, the upload can be reinstated at v7 SHA-pinned.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `refactor/125-task-1-7-bump-codecov-action-v4-v7 @ 536ce3c` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Removed "Upload coverage to Codecov" step (codecov-action@v4, tokenless, `fail_ci_if_error: false`); replaced with rationale comment pointing at the local coverage floor |

## Test Results

- Unit tests: 616 passed
- Integration tests: covered by unit suite (CI matrix legs unchanged)
- E2e tests: covered by existing workflow jobs (unchanged)
- Build: YAML validated (`yaml.safe_load`)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| codecov-action at v7 (SHA-pinned) with token secret and `fail_ci_if_error: true`; upload visible — **or upload step removed entirely with rationale recorded** | pass | Upload step removed; rationale in `.github/workflows/ci.yml:100-103` comment and Decision Record above; `grep -ri codecov .github/` shows no action reference |
| Coverage report for a main-branch run reachable/complete — or step removed | pass | Upload step removed by design; coverage still measured and enforced per leg via `--cov-fail-under=73` (`pyproject.toml:132`) |
| Test command of record passes at ≥ 616/616 | pass | `source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider` → 616 passed in 18.48s |

<!-- gitissue:qa v1 head=536ce3cbea70b9f781e1eb3bdde8c3cdb3926bd8 profile=light cycles=1 review=clean tests=616@536ce3cbea70b9f781e1eb3bdde8c3cdb3926bd8 ui=none -->
