### PR TITLE
fix(config): point settings example at claude-statusline (#132)

### DIFF
--- a/config/settings-example.json
+++ b/config/settings-example.json
@@ -1,7 +1,7 @@
 {
   "statusLine": {
     "type": "command",
-    "command": "~/.claude/statusline.sh",
+    "command": "claude-statusline",
     "padding": 0
   }
 }

--- a/tests/python/test_settings_examples.py
+++ b/tests/python/test_settings_examples.py
@@ -1,0 +1,46 @@
+"""Regression guards for shipped settings examples (F-DEAD-003, #132).
+
+The v1.17.0 Python-only migration deleted ~/.claude/statusline.sh, but
+config/settings-example.json kept pointing at it — anyone copying the
+example got a permanently blank status line. These tests pin the example
+to a command that actually exists as a package entry point.
+"""
+
+import json
+import re
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _entry_point_names():
+    """Extract command names from [project.scripts] in pyproject.toml."""
+    pyproject = (_PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    section = re.search(r"\[project\.scripts\]\n(.*?)(?:\n\[|\Z)", pyproject, re.DOTALL)
+    assert section is not None, "[project.scripts] section missing from pyproject.toml"
+    return {
+        line.split("=", 1)[0].strip()
+        for line in section.group(1).splitlines()
+        if "=" in line
+    }
+
+
+class TestSettingsExample:
+    """Tests that config/settings-example.json stays installable."""
+
+    def _load_example(self):
+        path = _PROJECT_ROOT / "config" / "settings-example.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_references_installed_command(self):
+        command = self._load_example()["statusLine"]["command"]
+        assert command in _entry_point_names(), (
+            f"settings-example.json references {command!r}, which is not a "
+            "[project.scripts] entry point — copying it yields a blank status line"
+        )
+
+    def test_no_dead_statusline_script_path(self):
+        raw = (_PROJECT_ROOT / "config" / "settings-example.json").read_text(
+            encoding="utf-8"
+        )
+        assert "statusline.sh" not in raw

--- a/tests/python/test_settings_examples.py
+++ b/tests/python/test_settings_examples.py
@@ -18,11 +18,7 @@ def _entry_point_names():
     pyproject = (_PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
     section = re.search(r"\[project\.scripts\]\n(.*?)(?:\n\[|\Z)", pyproject, re.DOTALL)
     assert section is not None, "[project.scripts] section missing from pyproject.toml"
-    return {
-        line.split("=", 1)[0].strip()
-        for line in section.group(1).splitlines()
-        if "=" in line
-    }
+    return {line.split("=", 1)[0].strip() for line in section.group(1).splitlines() if "=" in line}
 
 
 class TestSettingsExample:
@@ -40,7 +36,5 @@ class TestSettingsExample:
         )
 
     def test_no_dead_statusline_script_path(self):
-        raw = (_PROJECT_ROOT / "config" / "settings-example.json").read_text(
-            encoding="utf-8"
-        )
+        raw = (_PROJECT_ROOT / "config" / "settings-example.json").read_text(encoding="utf-8")
         assert "statusline.sh" not in raw


### PR DESCRIPTION
Closes #132

## Summary

Task 2.7 of the modernization plan (closes F-DEAD-003). The v1.17.0 Python-only migration removed `~/.claude/statusline.sh`, but `config/settings-example.json` kept pointing at it — anyone copying the example into their Claude Code settings got a permanently blank status line. The example now uses the `claude-statusline` console script defined in `[project.scripts]`, matching the canonical snippet already documented in README.md and docs/installation.md, and a regression test pins it to a real entry point so the dead-pointer class of bug cannot silently return.

Note on scope: after this change the only remaining `statusline.sh` match in the tree is one line inside `INSTALLATION_FIX.md`'s quoted v1.17.0 installer output; that document is banner-marked "historical… preserved for reference only", so its log excerpt is retained deliberately rather than falsified. No README/docs file references `settings-example.json`, so there were no dangling links to reconcile.

## Approach

Selected option 1 — implement per plan task directions: rewrite the example's `statusLine.command` to the live entry point and add a regression guard test asserting the referenced command exists in `[project.scripts]` and no dead script path remains.

## Decision Record

- **Root cause:** config/settings-example.json:4 points at ~/.claude/statusline.sh, deleted in the v1.17.0 Python-only migration — users copying it get a permanently blank status line.
- **Options considered:** Option 1 — Implement per issue body fix directions with mirrored edits in both copies where synced; Option 2 — Defer/merge with dependent task
- **Options rejected:** Option 2 — no reason recorded in the reused analysis
- **Selected option:** Option 1 — Implement per MODERNIZATION_PLAN.md task directions
- **Residual risk:** low — sole residual `statusline.sh` mention is the deliberately preserved historical log quote in INSTALLATION_FIX.md; no user-copyable config references a missing file.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `main @ be7e6af` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `config/settings-example.json` | `statusLine.command`: `~/.claude/statusline.sh` → `claude-statusline` (live `[project.scripts]` entry point) |
| `tests/python/test_settings_examples.py` | New regression guards: example command must be an installed entry point; dead `statusline.sh` path must stay absent |

## Test Results

- Unit tests: 744 passed (full `pytest tests/python/ -q -p no:cacheprovider` run, includes 2 new)
- Integration tests: n/a — single-suite pytest project
- E2e tests: n/a
- Build: passed (clean collection/import across suite)
- QA cycles: 1 (review clean, first pass)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Example settings reference a command that exists (`command -v claude-statusline` style check documented) — or the file is deleted with rationale in the PR | pass | `claude-statusline` defined at `pyproject.toml:41` under `[project.scripts]`; enforced by `tests/python/test_settings_examples.py::TestSettingsExample::test_references_installed_command` |
| If kept: README/docs link or remove any dangling references to `settings-example.json` consistently | pass | Repo-wide grep: zero references to `settings-example.json` outside `.gitissue/` caches — nothing dangling to update |

<!-- gitissue:qa v1 head=e4afcca1044d826eafe47a6029b8e5dbd59a9750 profile=light cycles=1 review=clean tests=744@e4afcca1044d826eafe47a6029b8e5dbd59a9750 ui=none -->
