### PR TITLE
chore(deps): apply the python floor decision (#134)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -142,7 +142,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thank you for your interest in contributing to Claude Code Status Line! This doc
 
 - **Git** - Version control
 - **jq** - JSON processor (for bash scripts)
-- **Python 3.9+** - For Python script and testing
+- **Python 3.10+** - For Python script and testing
 - **Bats** - Bash Automated Testing System
 
 ### Installing Dependencies

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Yes. MIT licensed, zero external dependencies.
 No. Session data stays local in `~/.claude/statusline/`. Analytics read from `~/.claude/projects/`.
 
 **What runtimes does it support?**
-Python 3.9+. Install via `pip install context-stats`.
+Python 3.10+. Install via `pip install context-stats`.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - **Git** - Version control
-- **Python 3.9+** - For Python package and testing
+- **Python 3.10+** - For Python package and testing
 - **Bats** - Bash Automated Testing System (optional, for bash tests)
 - **pre-commit** - Git hook framework (optional, for automated code quality)
 
@@ -67,11 +67,9 @@ pre-commit install
 
 ### Regenerating the dev-dependency constraints file
 
-`requirements-dev.constraints.txt` pins every dev requirement (and its transitive dependencies) to exact versions so local installs and CI are reproducible; it is consumed via `pip install -r requirements-dev.txt -c requirements-dev.constraints.txt` in every CI job that installs dev dependencies (`python-lint`, `python-test`, and the release workflow's test job). To regenerate it after editing `requirements-dev.txt`, resolve at the **Python 3.9 floor** — the oldest version CI supports — so the pins stay installable across the whole 3.9–3.12 matrix: run `pip download --dest /tmp/wheels --python-version 3.9 --only-binary=:all: -r requirements-dev.txt`, read the exact resolved versions from the downloaded wheel filenames, and write them into the constraints file as `name==version` lines (canonical PyPI names, alphabetically sorted).
+`requirements-dev.constraints.txt` pins every dev requirement (and its transitive dependencies) to exact versions so local installs and CI are reproducible; it is consumed via `pip install -r requirements-dev.txt -c requirements-dev.constraints.txt` in every CI job that installs dev dependencies (`python-lint`, `python-test`, and the release workflow's test job). To regenerate it after editing `requirements-dev.txt`, resolve at the **Python 3.10 floor** — the oldest version CI supports — so the pins stay installable across the whole 3.10–3.14 matrix: run `pip download --dest /tmp/wheels --python-version 3.10 --only-binary=:all: -r requirements-dev.txt`, read the exact resolved versions from the downloaded wheel filenames, and write them into the constraints file as `name==version` lines (canonical PyPI names, alphabetically sorted).
 
-**Version-capped floor dependencies (F-DEP-002):** when a dependency's newer releases drop a matrix Python, `requirements-dev.txt` must carry an explicit **upper cap** at that boundary alongside the floor — e.g. pre-commit ≥ 4.4 requires Python ≥ 3.10 while the matrix floors at 3.9, so it is declared as `pre-commit>=3.6.0,<4.4` (raising that floor/cap pair is owned by Task 3.1, [#133](https://github.com/luongnv89/context-stats/issues/133)). The constraints file then pins a single unmarked version below the cap (the newest release whose [`Requires-Python`](https://pypi.org/pypi/pre-commit/json) admits the oldest supported Python — 4.3.0 today). Never replace the cap with PEP 508 environment-marker-scoped pins in the constraints file: `pip download --python-version` evaluates `python_version` markers against the _running_ interpreter rather than the target one, so marked pins cannot be verified with the cross-version procedure below and silently resolve wrong on other legs.
-
-Then verify before committing: re-run that same download command with `-c requirements-dev.constraints.txt` for each matrix Python (`3.9`, `3.10`, `3.11`, `3.12`) — all four must resolve without conflicts — and run the recorded test command in a clean venv installed with the constraints.
+Then verify before committing: re-run that same download command with `-c requirements-dev.constraints.txt` for each matrix Python (`3.10`, `3.11`, `3.12`, `3.13`, `3.14`) — all five must resolve without conflicts — and run the recorded test command in a clean venv installed with the constraints.
 
 ### Security auditing
 
@@ -85,7 +83,7 @@ bash scripts/pip-audit-locked.sh
 
 CI runs the same audit on every push/PR (`dependency-scan` job in `.github/workflows/ci.yml`) and weekly ([`.github/workflows/security-audit.yml`](../.github/workflows/security-audit.yml)). The gate fails on **any** known advisory — stricter than the High/Critical requirement.
 
-**Exception policy:** an advisory may only be silenced with a filed ticket. Add one `--ignore-vuln <ID>` line per advisory to `scripts/pip-audit-locked.sh`, reference the ticket in that script's header comment, and note it in `requirements-dev.constraints.txt`. Current exceptions are tracked in [#161](https://github.com/luongnv89/context-stats/issues/161): every fix version requires Python >= 3.10 directly, or conflicts across the CI matrix with the Python 3.9-floor pins, so they become actionable when the minimum supported Python rises to 3.10+ — bump the affected pins and delete the matching flags then. When a **new** advisory appears: first try bumping the pin within what resolves at the 3.9 floor; only if no fix installs, file a ticket and add the flag.
+**Exception policy:** an advisory may only be silenced with a filed ticket. Add one `--ignore-vuln <ID>` line per advisory to `scripts/pip-audit-locked.sh`, reference the ticket in that script's header comment, and note it in `requirements-dev.constraints.txt`. The exceptions tracked in [#161](https://github.com/luongnv89/context-stats/issues/161) — every fix version required Python >= 3.10 directly, or conflicted across the CI matrix with the old Python 3.9-floor pins — became actionable when the minimum supported Python rose to 3.10 ([ADR 0001](adr/python-support-floor.md), #133/#134): the affected pins were bumped and their flags deleted as part of that task. When a **new** advisory appears: first try bumping the pin within what resolves at the 3.10 floor; only if no fix installs, file a ticket and add the flag.
 
 ## Project Layout
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -47,7 +47,7 @@
           "mainEntity": [
             { "@type": "Question", "name": "Does context-stats send any data to the cloud?", "acceptedAnswer": { "@type": "Answer", "text": "No. All session data stays local in ~/.claude/statusline/. There are no network requests, no telemetry, no external API calls of any kind." } },
             { "@type": "Question", "name": "Will it slow down my Claude Code sessions?", "acceptedAnswer": { "@type": "Answer", "text": "No. The statusline script runs synchronously on each prompt in under 10ms. Git operations have a 5-second timeout to prevent hangs." } },
-            { "@type": "Question", "name": "Does it work on Windows?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. context-stats is pure Python 3.9+ with zero external dependencies and runs on macOS, Linux, and Windows." } },
+            { "@type": "Question", "name": "Does it work on Windows?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. context-stats is pure Python 3.10+ with zero external dependencies and runs on macOS, Linux, and Windows." } },
             { "@type": "Question", "name": "What is cache keep-warm and why do I need it?", "acceptedAnswer": { "@type": "Answer", "text": "Claude's prompt cache has a 5-minute TTL. cache-warm runs a lightweight heartbeat every 4 minutes to keep the cache alive for up to 30 minutes." } },
             { "@type": "Question", "name": "What does the compaction marker mean?", "acceptedAnswer": { "@type": "Answer", "text": "A >50% drop in token count between interactions is detected automatically and marked with a triangle. If MI was below 0.6 at that point, it is flagged as potentially lossy." } }
           ]
@@ -657,7 +657,7 @@
                 <!-- INSTALL -->
                 <section id="install">
                     <h2>Install in 60 seconds</h2>
-                    <p>Pure Python 3.9+, zero external dependencies. macOS, Linux, and Windows.</p>
+                    <p>Pure Python 3.10+, zero external dependencies. macOS, Linux, and Windows.</p>
                     <div class="term" data-copy="pip install context-stats">
                         <div class="term-bar">
                             <span class="d r"></span><span class="d y"></span><span class="d g"></span>
@@ -1085,7 +1085,7 @@ color_mi_high=<span class="g">#10B981</span></pre>
                     </details>
                     <details>
                         <summary>Does it work on Windows?</summary>
-                        <p>Yes. context-stats is pure Python 3.9+ with zero external dependencies and runs on macOS, Linux, and Windows.</p>
+                        <p>Yes. context-stats is pure Python 3.10+ with zero external dependencies and runs on macOS, Linux, and Windows.</p>
                     </details>
                     <details>
                         <summary>How accurate are the token counts?</summary>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1067,7 +1067,7 @@
                     <span class="section-label">Get started</span>
                     <h2>Install in under 60 seconds.</h2>
                     <p>
-                        Pure Python 3.9+, zero external dependencies. Copy a command, wire the
+                        Pure Python 3.10+, zero external dependencies. Copy a command, wire the
                         statusline, restart Claude Code.
                     </p>
                 </div>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,7 +99,7 @@ Windows:
 
 ## Requirements
 
-Python 3.9+ is the only requirement. No additional system packages needed.
+Python 3.10+ is the only requirement. No additional system packages needed.
 
 ## Verify Installation
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # context-stats — Real-Time Context Monitoring for Claude Code
 
-> Track token usage, catch context degradation early, and optimize your Claude Code spend — all without leaving your terminal. Zero dependencies, MIT licensed, pure Python 3.9+.
+> Track token usage, catch context degradation early, and optimize your Claude Code spend — all without leaving your terminal. Zero dependencies, MIT licensed, pure Python 3.10+.
 
 ## Landing Page
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -74,7 +74,7 @@ echo {"model":{"display_name":"Test"}} | python %USERPROFILE%\.claude\statusline
 
 ### pip install fails
 
-1. Ensure Python 3.9+:
+1. Ensure Python 3.10+:
 
    ```bash
    python3 --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.24.0"
 description = "Monitor your Claude Code session context in real-time - track token usage and never run out of context"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Nguyen Luong", email = "luongnv89@gmail.com" }
 ]
@@ -30,11 +30,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
 ]
@@ -72,7 +72,7 @@ include = [
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 100
 src = ["src"]
 
@@ -93,7 +93,7 @@ quote-style = "double"
 indent-style = "space"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_ignores = true
 strict_optional = true
@@ -122,7 +122,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]
 # Coverage floor (issue #117, F-TEST-006): measured over src/claude_statusline
-# on main — 2750 statements, 721 missed, identical across the Python 3.9-3.12
+# on main — 2750 statements, 721 missed, identical across the Python 3.10-3.14
 # CI matrix legs and stable between interpreters locally. The precise total is
 # 73.78%, and coverage compares fail-under against the unrounded value, so a
 # literal 74 would fail on main itself; 73 is today's measured-value floor.

--- a/requirements-dev.constraints.txt
+++ b/requirements-dev.constraints.txt
@@ -1,67 +1,63 @@
 # Pinned development dependencies — consumed with `-c` by CI and local installs:
 #   pip install -r requirements-dev.txt -c requirements-dev.constraints.txt
 #
-# Resolved from requirements-dev.txt at the Python 3.9 floor (the oldest
+# Resolved from requirements-dev.txt at the Python 3.10 floor (the oldest
 # version CI supports), so every pin installs across the full CI matrix.
 # Regeneration is documented in docs/DEVELOPMENT.md ("Regenerating the
 # dev-dependency constraints file").
 #
-# Security exceptions: the advisory IDs ignored by scripts/pip-audit-
-# locked.sh (12 findings across msgpack, filelock, pip, pytest, requests,
-# urllib3 and virtualenv) currently have no fix installable across the
-# whole CI matrix — every fix version requires Python >= 3.10 directly,
-# or conflicts across the matrix with the Python 3.9-floor pins. They are
-# silenced (with a filed ticket, #161) by the CI audit until the minimum
-# supported Python rises to 3.10+. See docs/DEVELOPMENT.md ("Security
+# Security exceptions: any advisory ID ignored by scripts/pip-audit-
+# locked.sh is listed here with its filed ticket. The 12 findings from
+# ticket #161 (msgpack, filelock, pip, pytest, requests, urllib3 and
+# virtualenv) became actionable when the minimum supported Python rose to
+# 3.10 (ADR 0001, #133/#134) and were cleared by this regeneration — their
+# --ignore-vuln flags are gone. See docs/DEVELOPMENT.md ("Security
 # auditing").
+ast-serialize==0.8.0
 boolean.py==5.0
-cachecontrol==0.14.3
+cachecontrol==0.14.4
 certifi==2026.7.22
-cfgv==3.4.0
+cfgv==3.5.0
 charset-normalizer==3.5.1
-coverage==7.10.7
-cyclonedx-python-lib==9.1.0
+coverage==7.15.4
+cyclonedx-python-lib==11.12.0
 defusedxml==0.7.1
 distlib==0.4.3
-filelock==3.19.1
-identify==2.6.15
+filelock==3.32.3
+identify==2.6.19
 idna==3.19
-iniconfig==2.1.0
+iniconfig==2.3.0
 librt==0.15.0
 license-expression==30.4.4
-markdown-it-py==3.0.0
+markdown-it-py==4.2.0
 mdurl==0.1.2
-msgpack==1.1.2
-mypy==1.19.1
+msgpack==1.2.1
+mypy==2.3.1
 mypy-extensions==1.1.0
 nodeenv==1.10.0
 packageurl-python==0.17.6
 packaging==26.3
 pathspec==1.1.1
-pip==26.0.1
+pip==26.2.1
 pip-api==0.0.34
-pip-audit==2.9.0
+pip-audit==2.10.1
 pip-requirements-parser==32.0.1
-platformdirs==4.4.0
+platformdirs==4.11.3
 pluggy==1.6.0
-# Single unmarked pin: releases >= 4.4 require Python >= 3.10 while the CI
-# matrix floors at 3.9, so requirements-dev.txt caps pre-commit < 4.4
-# (F-DEP-002; raising the floor/cap pair is Task 3.1, #133). Keep this pin
-# marker-free — pip download --python-version evaluates python_version
-# markers against the running interpreter, not the target, so marked pins
-# cannot be verified with the documented cross-version procedure.
-pre-commit==4.3.0
+pre-commit==4.6.2
 py-serializable==2.1.0
 pygments==2.21.0
 pyparsing==3.3.2
-pytest==8.4.2
+pytest==9.1.1
 pytest-cov==7.1.0
+python-discovery==1.5.2
 PyYAML==6.0.3
-requests==2.32.5
+requests==2.34.2
 rich==15.0.0
 ruff==0.16.4
 sortedcontainers==2.4.0
-toml==0.10.2
+tomli==2.4.1
+tomli-w==1.2.0
 typing-extensions==4.16.0
-urllib3==2.6.3
-virtualenv==20.35.4
+urllib3==2.7.0
+virtualenv==21.7.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,10 +9,7 @@ ruff>=0.1.0
 mypy>=1.7.0
 
 # Pre-commit hooks
-# Capped below 4.4: pre-commit >= 4.4 requires Python >= 3.10 while the CI
-# matrix floors at 3.9 (F-DEP-002). Raising the Python floor together with
-# this cap is owned by Task 3.1 (#133) — do not widen the cap until then.
-pre-commit>=3.6.0,<4.4
+pre-commit>=3.6.0
 
 # Security auditing
 pip-audit>=2.7,<3

--- a/scripts/pip-audit-locked.sh
+++ b/scripts/pip-audit-locked.sh
@@ -6,24 +6,14 @@
 # venv. Exits non-zero on any known advisory NOT listed below, so a new
 # High/Critical advisory fails the gate immediately.
 #
-# Every --ignore-vuln entry MUST reference a filed ticket (#161). All current
-# entries have fix versions requiring Python >= 3.10 (directly or via matrix
-# conflicts with the Python 3.9 floor pins) and MUST be revisited when the
-# minimum supported Python rises to 3.10+.
+# The 12 ticketed exceptions from #161 (msgpack, filelock, pip, pytest,
+# requests, urllib3 and virtualenv) were cleared when the minimum supported
+# Python rose to 3.10 (ADR 0001, #133/#134): their fix versions now install
+# across the whole CI matrix, so no --ignore-vuln flags remain. New advisories
+# may only be silenced with a filed ticket — see docs/DEVELOPMENT.md
+# ("Security auditing").
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-exec pip-audit -r requirements-dev.constraints.txt --progress-spinner off \
-	--ignore-vuln PYSEC-2026-3625 \
-	--ignore-vuln PYSEC-2026-1375 \
-	--ignore-vuln PYSEC-2026-1374 \
-	--ignore-vuln PYSEC-2026-196 \
-	--ignore-vuln PYSEC-2026-2875 \
-	--ignore-vuln PYSEC-2026-2876 \
-	--ignore-vuln PYSEC-2026-3721 \
-	--ignore-vuln PYSEC-2026-1845 \
-	--ignore-vuln PYSEC-2026-2275 \
-	--ignore-vuln PYSEC-2026-142 \
-	--ignore-vuln PYSEC-2026-141 \
-	--ignore-vuln PYSEC-2026-2009
+exec pip-audit -r requirements-dev.constraints.txt --progress-spinner off

--- a/src/claude_statusline/graphs/statistics.py
+++ b/src/claude_statusline/graphs/statistics.py
@@ -173,7 +173,7 @@ def compute_tps(
     # Reconstruct per-turn (output, api_time_ms) from consecutive samples,
     # keeping only turns with real elapsed API time and real output.
     turns: list[tuple[int, int]] = []
-    for (_, prev_dur), (out, cur_dur) in zip(samples, samples[1:]):
+    for (_, prev_dur), (out, cur_dur) in zip(samples, samples[1:], strict=False):
         # A zero/negative previous cumulative means a legacy row without the
         # field — differencing against it would understate throughput badly.
         if prev_dur <= 0:


### PR DESCRIPTION
Closes #134

## Summary

Execute the Task 3.1 decision (ADR 0001, #133): raise the Python support floor from 3.9 (EOL) to >=3.10 across packaging metadata, tooling targets, CI matrix legs, dev-dependency constraints, pip-audit exceptions, and every documented floor mention. Closes findings F-DEP-010 and F-DEP-002.

## Approach

Option 1 — apply `docs/adr/python-support-floor.md` ("Artifacts Task 3.2 (#134) must update") verbatim: packaging/tooling floors rise together, CI drops the EOL 3.9 leg and adds 3.13/3.14, the interim pre-commit <4.4 cap is removed, constraints are regenerated at the 3.10 floor per the documented cross-version procedure, and the 12 ticketed PYSEC exceptions (#161) were verified fixed by a live audit before their flags were deleted.

## Decision Record

- **Root cause:** pyproject classifiers, CI matrix legs, and constraint floors still encoded the interim >=3.9 posture (with the interim F-DEP-002 cap) awaiting execution of the Task 3.1 ADR decision.
- **Options considered:** Option 1 — implement per ADR/plan task directions with both-copies parity discipline; Option 2 — defer/merge with dependent task.
- **Options rejected:** Option 2 — deferral breaks downstream dependents (#135); the issue closes concrete findings in a phased epic.
- **Selected option:** Option 1
- **Residual risk:** none identified; ADR 0001 schedules the next floor decision (>=3.11) before/around 2026-10-31.

Analyzed at: `issue-134-task-3-2-apply-the-python-floor @ dbc72df` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `requires-python >=3.10`; classifiers 3.9→dropped, 3.14 added; ruff `py310`; mypy `3.10`; coverage-comment matrix range refreshed |
| `.github/workflows/ci.yml` | `python-test` and `e2e-install-pip` matrices: drop `'3.9'`, add `'3.13'`, `'3.14'` |
| `requirements-dev.txt` | Remove the F-DEP-002 `<4.4` cap and its comment: `pre-commit>=3.6.0` |
| `requirements-dev.constraints.txt` | Regenerated at the 3.10 floor (48 pins resolve identically on 3.10–3.14); `pre-commit==4.6.2`; header comments rewritten |
| `scripts/pip-audit-locked.sh` | All 12 `--ignore-vuln PYSEC-*` flags deleted (live audit reports no known vulnerabilities); header updated |
| `src/claude_statusline/graphs/statistics.py` | Explicit `strict=False` on the consecutive-samples `zip()` — the one B905 site newly flagged by the py310 target |
| `README.md`, `CONTRIBUTING.md`, `docs/*` | Floor mentions swept to "Python 3.10+" (`DEVELOPMENT.md` regeneration procedure now documents the 3.10 floor and 5-leg verify; F-DEP-002 section replaced by its resolution) |

## Test Results

- Unit tests: 744 passed
- Integration tests: covered by the suite above (CI runs the OS matrix)
- E2e tests: not run locally (CI matrix legs cover install/exec)
- Build: passed — `python -m build` sdist + wheel; both carry `Requires-Python: >=3.10` and classifiers 3.10–3.14
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `pyproject.toml` requires-python and classifiers match the decided floor; CI matrix contains no EOL legs | pass | `pyproject.toml:11` `">=3.10"`, classifiers 3.10–3.14; `ci.yml:53,:145` matrices `'3.10'…'3.14'` |
| Full constraints resolve and the recorded test command passes at ≥616/616 on every remaining matrix leg | pass | `pip download --python-version {3.10…3.14} -c requirements-dev.constraints.txt` resolved 48 wheels on all five legs; recorded command: 744 passed locally (Python 3.14.7) |
| Package builds: `python -m build` sdist+wheel succeed | pass | `Successfully built context_stats-1.24.0.tar.gz and context_stats-1.24.0-py3-none-any.whl`; METADATA verified |

<!-- gitissue:qa v1 head=dbc72dfac17f8dd6b655caa72f1fc9246fdd4b9f profile=full cycles=1 review=clean tests=744@dbc72dfac17f8dd6b655caa72f1fc9246fdd4b9f ui=none:clean@dbc72dfac17f8dd6b655caa72f1fc9246fdd4b9f -->
