### PR TITLE
chore(deps): require twine >=7 in the dev extra (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Publish toolchain floor: twine 7** — The `dev` extra now requires `twine>=7.0.0` (was `>=4.0.0`). The documented publish procedure (`twine check` / `twine upload`) is unchanged, but twine 7 no longer accepts metadata version 2.0 artifacts on upload; this project's hatchling-built dists emit metadata 2.5 and pass `twine check` unchanged (#135)
+
 ## [1.24.0] - 2026-06-17
 
 ### Added
@@ -19,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Logo path in changelog** — Fixed the logo path references in the changelog navigation and footer (#93)
 - **Changelog nav layout** — Removed the search box and fixed the changelog navigation layout for better usability (#101)
 
+[Unreleased]: https://github.com/luongnv89/context-stats/compare/v1.24.0...HEAD
 [1.24.0]: https://github.com/luongnv89/context-stats/compare/v1.23.0...v1.24.0
 
 ## [1.23.0] - 2026-06-16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.7.0",
     "build>=1.0.0",
-    "twine>=4.0.0",
+    "twine>=7.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Description

Closes #135

Task 3.3 of the modernization plan: raise the publish-tool floor from
twine>=4.0.0 to twine>=7.0.0 (F-DEP-009, W4 — release-path blast radius only).

## Approach

- Bumped `twine>=4.0.0` → `twine>=7.0.0` in the `[project.optional-dependencies] dev`
  extra (`pyproject.toml`). Twine intentionally stays out of
  `requirements-dev.txt`/`requirements-dev.constraints.txt`: publish tools are not
  installed by CI, matching the existing convention where `build` also lives only
  in the dev extra.
- Checked the twine 7.0.0 changelog (2026-07-27): the one removal that can affect a
  publish flow is rejecting metadata version 2.0 artifacts on upload (#1317 in
  twine). This project's hatchling-built dists emit **metadata 2.5**, so nothing
  changes for us; all other 7.0.0 entries are bugfixes (.pypirc UTF-8, `--version`
  output, rich hang, non-standard HTTP codes).
- Validated end-to-end without publishing anywhere:
  `python -m build --outdir /tmp/cs-dist` then `twine check /tmp/cs-dist/*` → both
  dists PASSED, exit 0, under twine 7.0.0 installed against the locked constraints.
- Release workflow (`.github/workflows/release.yml`) never invokes twine — it ships
  GitHub-release tarball/zip archives only, so no workflow change is needed. The
  documented publish procedure (docs/DEPLOYMENT.md "Publishing to PyPI",
  docs/DEVELOPMENT.md "Building") uses `twine check`/`twine upload`, whose syntax is
  unchanged in twine 7.

## Decision Record

- **Root cause:** publish toolchain floor pinned at twine>=4 while twine 7 is the
  current major with release-path behavior changes.
- **Selected option:** minimal dev-extra floor bump with build + `twine check`
  verification; no lockfile/constraints churn.
- **Options rejected:** adding twine to requirements-dev.txt and regenerating
  constraints at the 3.10 floor — no CI consumer installs twine, so this adds
  maintenance surface with zero gate value; deferring — closes a concrete plan
  finding in a phased epic, deferral breaks downstream task ordering.
- **Residual risk:** low.

## Changes

| File | Change |
| ---- | ------ |
| `pyproject.toml` | dev extra: `twine>=4.0.0` → `twine>=7.0.0` |
| `CHANGELOG.md` | New `[Unreleased]` section noting the floor bump and the metadata-2.0 upload removal (no impact here) |

## Test Results

- Recorded command: `source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider`
  → **744 passed** on the committed tree (≥ 616 required)
- `twine check /tmp/cs-dist/*` → exit 0 (both dists PASSED)
- `ruff check .` → clean; `mypy src scripts` → clean

## Acceptance Criteria Verification

| Criterion | Result |
| --------- | ------ |
| Dev extra requires twine ≥7; `twine check` on built dists passes | ✅ `pyproject.toml` now `twine>=7.0.0`; fresh build checked under twine 7.0.0, exit 0 |
| Release workflow / documented publish procedure validated; behavior change noted in CHANGELOG | ✅ Workflow verified twine-free; documented commands unchanged under twine 7; metadata-2.0 removal noted under `[Unreleased]` |
| Test command of record passes at ≥ 616/616 | ✅ 744/744 |

<!-- gitissue:qa v1 cycles=1 clean=true head=15bee23eb3f8f695c30f1e0df6b7482ca1a19928 -->