### PR TITLE
test(coverage): close phase-P3 test gaps F-TEST-002..008 (#137)

### DIFF
--- a/tests/python/test_analytics_units.py
+++ b/tests/python/test_analytics_units.py
@@ -168,9 +168,7 @@ class TestLoadSessionStats:
         f = tmp_path / "statusline.mixed.state"
         f.write_text(
             "garbage-without-commas\n"
-            ",,,\n"
-            + _csv_line(ts=5, sid="mixed")
-            + "\nnot-a-number,also-bad\n"
+            ",,,\n" + _csv_line(ts=5, sid="mixed") + "\nnot-a-number,also-bad\n"
         )
         stats = _load_session_stats(f)
         assert stats is not None
@@ -383,9 +381,7 @@ class TestStateIoFailures:
         assert sorted(StateFile(None).list_sessions()) == ["alpha", "beta"]
 
     def test_from_csv_line_safe_int_float_fallbacks(self):
-        row = (
-            "1710288000,abc,def,ghi,jkl,mno,pqr,vwx,stu,yz,ab,cd,ef,gh,ij\n"
-        )
+        row = "1710288000,abc,def,ghi,jkl,mno,pqr,vwx,stu,yz,ab,cd,ef,gh,ij\n"
         entry = StateEntry.from_csv_line(row)
         assert entry is not None
         assert entry.timestamp == 1710288000

--- a/tests/python/test_analytics_units.py
+++ b/tests/python/test_analytics_units.py
@@ -1,0 +1,393 @@
+"""Direct unit tests for the analytics engine and state recovery paths
+(issue #139, F-TEST-004/F-TEST-005).
+
+Analytics: malformed CSV rows, empty/unreadable files, multi-project
+grouping, date filtering, aggregation math. State: tmp_path fault-injection
+for IO-failure recovery branches not already covered by
+test_state_robustness.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_statusline.analytics import (
+    ProjectStats,
+    SessionStats,
+    _discover_state_files,
+    _group_sessions_by_project,
+    _load_session_stats,
+    load_all_projects,
+)
+from claude_statusline.core.state import StateEntry, StateFile
+
+
+@pytest.fixture()
+def state_dirs(tmp_path, monkeypatch):
+    """Isolate both state dirs under tmp_path."""
+    monkeypatch.setattr(StateFile, "STATE_DIR", tmp_path / "state")
+    monkeypatch.setattr(StateFile, "OLD_STATE_DIR", tmp_path / "old")
+    return tmp_path
+
+
+def _csv_line(ts=1000, sid="s1", model="claude-opus", proj="/home/user/proj", **kw) -> str:
+    defaults: dict = {
+        "total_input_tokens": 1000,
+        "total_output_tokens": 200,
+        "current_input_tokens": 300,
+        "current_output_tokens": 50,
+        "cache_creation": 100,
+        "cache_read": 40,
+        "cost_usd": 0.05,
+        "lines_added": 10,
+        "lines_removed": 2,
+        "context_window_size": 200000,
+        "api_duration_ms": 1200,
+    }
+    defaults.update(kw)
+    e = StateEntry(
+        timestamp=ts,
+        session_id=sid,
+        model_id=model,
+        workspace_project_dir=proj,
+        **defaults,
+    )
+    return e.to_csv_line()
+
+
+def _session(sid="s1", proj="/p", start=1000, end=2000, cost=1.0, tin=100, tout=50, cc=10, cr=5):
+    s = SessionStats(
+        session_id=sid,
+        project_dir=proj,
+        model_id="claude-opus",
+        total_input_tokens=tin,
+        total_output_tokens=tout,
+        total_cache_creation=cc,
+        total_cache_read=cr,
+        cost_usd=cost,
+        start_time=start,
+        end_time=end,
+        entry_count=3,
+    )
+    return s
+
+
+# ---------------------------------------------------------------------------
+# SessionStats / ProjectStats value objects
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStats:
+    def test_total_tokens_sums_all_buckets(self):
+        s = _session(tin=100, tout=50, cc=10, cr=5)
+        assert s.total_tokens() == 165
+
+    def test_cache_hit_ratio_zero_total_guard(self):
+        s = _session(tin=0, tout=0, cc=0, cr=0)
+        assert s.cache_hit_ratio() == 0.0
+
+    def test_cache_hit_ratio_percentage(self):
+        s = _session(tin=0, tout=0, cc=30, cr=30)
+        assert s.cache_hit_ratio() == pytest.approx(50.0)
+
+    @pytest.mark.parametrize(
+        "model_id,family",
+        [
+            ("claude-opus-4-6", "opus"),
+            ("OPUS-thing", "opus"),
+            ("claude-sonnet-4", "sonnet"),
+            ("claude-haiku-latest", "haiku"),
+            ("something-else", "other"),
+            ("", "other"),
+        ],
+    )
+    def test_model_family_branches(self, model_id, family):
+        s = _session()
+        s.model_id = model_id
+        assert s.model_family() == family
+
+
+class TestProjectStats:
+    def test_dominant_model_majority(self):
+        p = ProjectStats(project_dir="/p")
+        p.sessions = [_session(), _session()]
+        # both default to claude-opus → opus dominates
+        assert p.dominant_model() == "opus"
+
+    def test_dominant_model_empty_is_other(self):
+        assert ProjectStats(project_dir="/p").dominant_model() == "other"
+
+    def test_project_name_extracts_last_component(self):
+        assert ProjectStats(project_dir="/a/b/c").project_name() == "c"
+        assert ProjectStats(project_dir="noslash").project_name() == "noslash"
+
+    def test_totals_and_ratio(self):
+        p = ProjectStats(
+            project_dir="/p",
+            total_input_tokens=10,
+            total_output_tokens=10,
+            total_cache_creation=20,
+            total_cache_read=60,
+        )
+        assert p.total_tokens() == 100
+        assert p.cache_hit_ratio() == pytest.approx(60.0)
+        assert ProjectStats(project_dir="/p").cache_hit_ratio() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _load_session_stats — parsing, corruption, IO failures
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSessionStats:
+    def test_happy_path_aggregates_final_entry(self, tmp_path):
+        f = tmp_path / "statusline.sess1.state"
+        f.write_text(
+            "\n".join(
+                [
+                    _csv_line(ts=1000, sid="sess1", proj="/w/alpha"),
+                    _csv_line(ts=2000, sid="sess1", proj="/w/alpha"),
+                ]
+            )
+            + "\n"
+        )
+        stats = _load_session_stats(f)
+        assert stats is not None
+        assert stats.session_id == "sess1"
+        assert stats.project_dir == "/w/alpha"
+        assert stats.start_time == 1000
+        assert stats.end_time == 2000
+        assert stats.entry_count == 2
+        assert stats.total_input_tokens == 1000
+        assert stats.cost_usd == 0.05
+
+    def test_malformed_rows_skipped_valid_rows_kept(self, tmp_path):
+        f = tmp_path / "statusline.mixed.state"
+        f.write_text(
+            "garbage-without-commas\n"
+            ",,,\n"
+            + _csv_line(ts=5, sid="mixed")
+            + "\nnot-a-number,also-bad\n"
+        )
+        stats = _load_session_stats(f)
+        assert stats is not None
+        assert stats.entry_count == 1
+
+    def test_empty_file_returns_none(self, tmp_path):
+        f = tmp_path / "statusline.empty.state"
+        f.write_text("\n \n")
+        assert _load_session_stats(f) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert _load_session_stats(tmp_path / "nope.state") is None
+
+    def test_unreadable_file_returns_none(self, tmp_path):
+        d = tmp_path / "statusline.isdir.state"
+        d.mkdir()  # opening a directory raises IsADirectoryError (an OSError)
+        assert _load_session_stats(d) is None
+
+    def test_legacy_two_field_rows_parse_with_defaults(self, tmp_path):
+        f = tmp_path / "statusline.oldfmt.state"
+        f.write_text("12345,777\n")
+        stats = _load_session_stats(f)
+        assert stats is not None
+        assert stats.session_id == "oldfmt"
+        assert stats.total_input_tokens == 777
+        assert stats.entry_count == 1
+
+
+# ---------------------------------------------------------------------------
+# grouping / filtering / discovery
+# ---------------------------------------------------------------------------
+
+
+class TestGroupSessionsByProject:
+    def test_multi_project_grouping_aggregates(self):
+        sessions = [
+            _session("a", "/proj/a", cost=1.0),
+            _session("b", "/proj/a", cost=2.0),
+            _session("c", "/proj/b", cost=4.0),
+        ]
+        projects = _group_sessions_by_project(sessions)
+        assert set(projects) == {"/proj/a", "/proj/b"}
+        pa = projects["/proj/a"]
+        assert pa.session_count == 2
+        assert pa.cost_usd == pytest.approx(3.0)
+        assert [s.session_id for s in pa.sessions] == ["a", "b"]
+
+    def test_since_days_filters_old_sessions_by_start(self):
+        import time
+
+        now = int(time.time())
+        recent = _session("recent", start=now - 86400, end=now)
+        old = _session("old", start=now - 40 * 86400, end=now - 35 * 86400)
+        projects = _group_sessions_by_project([recent, old], since_days=30)
+        ids = [s.session_id for p in projects.values() for s in p.sessions]
+        assert ids == ["recent"]
+
+    def test_boundary_start_exactly_at_cutoff_is_included(self):
+        import time
+
+        now = int(time.time())
+        cutoff_start = now - 30 * 86400  # condition excludes only start < cutoff
+        edge = _session("edge", start=cutoff_start, end=now)
+        projects = _group_sessions_by_project([edge], since_days=30)
+        assert [s.session_id for p in projects.values() for s in p.sessions] == ["edge"]
+
+
+class TestDiscoverAndLoadAll:
+    def test_discover_empty_when_dir_missing(self, state_dirs):
+        assert _discover_state_files() == []
+
+    def test_discover_skips_directories_and_sorts(self, state_dirs):
+        sd = StateFile.STATE_DIR
+        sd.mkdir(parents=True)
+        (sd / "statusline.b.state").write_text(_csv_line(sid="b"))
+        (sd / "statusline.a.state").write_text(_csv_line(sid="a"))
+        (sd / "statusline.dir.state").mkdir()
+        (sd / "unrelated.state").write_text("x")
+        names = [f.name for f in _discover_state_files()]
+        assert names == ["statusline.a.state", "statusline.b.state"]
+
+    def test_load_all_projects_sorted_by_total_tokens_desc(self, state_dirs):
+        sd = StateFile.STATE_DIR
+        sd.mkdir(parents=True)
+        # small project: 1 entry
+        (sd / "statusline.small.state").write_text(_csv_line(sid="small", proj="/p/small") + "\n")
+        # big project: final cumulative values are what count
+        big_lines = [
+            _csv_line(ts=1, sid="big", proj="/p/big", total_input_tokens=5000),
+            _csv_line(ts=2, sid="big", proj="/p/big", total_input_tokens=90000),
+        ]
+        (sd / "statusline.big.state").write_text("\n".join(big_lines) + "\n")
+        # unloadable file must be skipped silently
+        (sd / "statusline.junk.state").write_text("@@@\n")
+
+        projects = load_all_projects()
+        assert [p.project_dir for p in projects] == ["/p/big", "/p/small"]
+        assert projects[0].total_input_tokens == 90000
+        assert projects[0].sessions[0].session_id == "big"
+
+    def test_load_all_projects_respects_since_days(self, state_dirs):
+        import time
+
+        sd = StateFile.STATE_DIR
+        sd.mkdir(parents=True)
+        ancient_ts = int(time.time()) - 400 * 86400
+        (sd / "statusline.ancient.state").write_text(
+            _csv_line(ts=ancient_ts, sid="ancient", proj="/p/old") + "\n"
+        )
+        assert load_all_projects(since_days=30) == []
+
+
+# ---------------------------------------------------------------------------
+# core/state.py IO-failure recovery branches (fault injection)
+# ---------------------------------------------------------------------------
+
+
+class TestStateIoFailures:
+    def test_read_history_oserror_warns_and_returns_empty(self, state_dirs, capsys):
+        sf = StateFile("iofail")
+        sf.file_path.write_text(_csv_line(sid="iofail") + "\n")
+        with patch.object(Path, "read_text", side_effect=OSError("denied")):
+            entries = sf.read_history()
+        assert entries == []
+        assert "failed to read state history" in capsys.readouterr().err
+
+    def test_read_tail_oserror_warns_and_returns_empty(self, state_dirs, capsys):
+        sf = StateFile("iotail")
+        sf.file_path.write_text(_csv_line(sid="iotail") + "\n")
+        with patch.object(Path, "read_text", side_effect=OSError("denied")):
+            assert sf.read_tail(5) == []
+        assert "failed to read state tail" in capsys.readouterr().err
+
+    def test_read_last_entry_oserror_warns_and_returns_none(self, state_dirs, capsys):
+        sf = StateFile("iolast")
+        sf.file_path.write_text(_csv_line(sid="iolast") + "\n")
+        with patch.object(Path, "read_text", side_effect=OSError("denied")):
+            assert sf.read_last_entry() is None
+        assert "failed to read last entry" in capsys.readouterr().err
+
+    def test_append_entry_oserror_on_open_warns(self, state_dirs, capsys):
+        sf = StateFile("iowrite")
+        sf.file_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.file_path.mkdir()  # os.open on a directory fails with OSError
+        sf.append_entry(StateEntry.from_csv_line(_csv_line(sid="iowrite")))
+        assert "failed to write state" in capsys.readouterr().err
+
+    def test_rotate_locked_oserror_warns(self, state_dirs, capsys):
+        class ExplodingHandle:
+            def seek(self, *a):
+                raise OSError("seek denied")
+
+        sf = StateFile("iorot")
+        sf._rotate_locked(ExplodingHandle())
+        assert "failed to rotate state file" in capsys.readouterr().err
+
+    def test_rotate_lines_rollback_removes_temp_on_replace_failure(
+        self, state_dirs, monkeypatch, capsys
+    ):
+        sf = StateFile("rollback")
+        lines = [f"l{i}\n" for i in range(20)]
+
+        def fail_replace(src, dst):
+            raise OSError("replace denied")
+
+        monkeypatch.setattr("claude_statusline.core.state.os.replace", fail_replace)
+        with pytest.raises(OSError):
+            sf._rotate_lines(sf.file_path, lines)
+        # temp file cleaned up, target untouched
+        leftovers = list(StateFile.STATE_DIR.glob("*.tmp")) if StateFile.STATE_DIR.exists() else []
+        assert leftovers == []
+
+    def test_maybe_rotate_noop_for_missing_file(self, state_dirs):
+        sf = StateFile("ghost")
+        sf._maybe_rotate()  # early return, no exception
+
+    def test_maybe_rotate_oserror_warns(self, state_dirs, capsys):
+        sf = StateFile("rotdir")
+        sf.file_path.parent.mkdir(parents=True, exist_ok=True)
+        sf.file_path.mkdir()  # open() on a directory raises OSError
+        sf._maybe_rotate()
+        assert "failed to rotate state file" in capsys.readouterr().err
+
+    def test_lock_unlock_survive_flock_errors(self, monkeypatch):
+        import claude_statusline.core.state as st
+
+        class BadFcntl:
+            LOCK_EX = 2
+            LOCK_UN = 8
+
+            def flock(self, *a, **k):
+                raise OSError("flock unsupported")
+
+        monkeypatch.setattr(st, "fcntl", BadFcntl())
+
+        class FakeHandle:
+            def fileno(self):
+                return 0
+
+        st._lock_state_file(FakeHandle())  # swallowed
+        st._unlock_state_file(FakeHandle())  # swallowed
+
+    def test_list_sessions_round_trip(self, state_dirs):
+        sd = StateFile.STATE_DIR
+        sd.mkdir(parents=True)
+        (sd / "statusline.alpha.state").write_text("")
+        (sd / "statusline.beta.state").write_text("")
+        (sd / "statusline..state").write_text("")  # empty id ignored
+        (sd / "other.txt").write_text("")
+        assert sorted(StateFile(None).list_sessions()) == ["alpha", "beta"]
+
+    def test_from_csv_line_safe_int_float_fallbacks(self):
+        row = (
+            "1710288000,abc,def,ghi,jkl,mno,pqr,vwx,stu,yz,ab,cd,ef,gh,ij\n"
+        )
+        entry = StateEntry.from_csv_line(row)
+        assert entry is not None
+        assert entry.timestamp == 1710288000
+        assert entry.total_input_tokens == 0
+        assert entry.cost_usd == 0.0

--- a/tests/python/test_cli_entry.py
+++ b/tests/python/test_cli_entry.py
@@ -1,0 +1,486 @@
+"""In-process tests for the context_stats CLI entry point (issue #137, F-TEST-002).
+
+Exercises parse_args/_normalize_argv argument-fallback paths and every
+subcommand-dispatch branch of main() without spawning subprocesses: argv is
+monkeypatched, the state dir lives under tmp_path, and subcommand workers are
+stubbed so dispatch itself is what's under test.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_statusline import __version__
+from claude_statusline.cli import context_stats as cs
+from claude_statusline.core.state import StateEntry, StateFile
+
+
+@pytest.fixture()
+def isolated(tmp_path, monkeypatch):
+    """Isolate state dirs and HOME under tmp_path so Config/StateFile never
+    touch the developer's real ~/.claude."""
+    state_dir = tmp_path / "state"
+    old_dir = tmp_path / "old"
+    monkeypatch.setattr(StateFile, "STATE_DIR", state_dir)
+    monkeypatch.setattr(StateFile, "OLD_STATE_DIR", old_dir)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    return tmp_path
+
+
+def _entry(**overrides) -> StateEntry:
+    defaults: dict = {
+        "timestamp": 1710288000,
+        "total_input_tokens": 100,
+        "total_output_tokens": 200,
+        "current_input_tokens": 300,
+        "current_output_tokens": 400,
+        "cache_creation": 500,
+        "cache_read": 600,
+        "cost_usd": 0.01,
+        "lines_added": 10,
+        "lines_removed": 5,
+        "session_id": "sess-cli",
+        "model_id": "claude-test",
+        "workspace_project_dir": "/tmp/proj",
+        "context_window_size": 200000,
+        "api_duration_ms": 1500,
+    }
+    defaults.update(overrides)
+    return StateEntry(**defaults)
+
+
+def _write_state(entries, session="sess-cli"):
+    sf = StateFile(session)
+    sf.file_path.write_text("".join(e.to_csv_line() + "\n" for e in entries))
+    return sf
+
+
+def _run_main(monkeypatch, argv):
+    monkeypatch.setattr(sys, "argv", ["context-stats", *argv])
+    cs.main()
+
+
+# ---------------------------------------------------------------------------
+# _normalize_argv — positional/action disambiguation fallbacks
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeArgv:
+    def test_no_arguments_defaults_to_latest_graph(self):
+        assert cs._normalize_argv([]) == ("graph", None, [])
+
+    def test_flags_only_keeps_flags_with_latest_session(self):
+        action, sid, remaining = cs._normalize_argv(["--no-watch", "--no-color"])
+        assert (action, sid) == ("graph", None)
+        assert remaining == ["--no-watch", "--no-color"]
+
+    def test_action_first_has_no_session_id(self):
+        action, sid, remaining = cs._normalize_argv(["export", "--output", "x.md"])
+        assert action == "export"
+        assert sid is None
+        assert remaining == ["--output", "x.md"]
+
+    def test_explain_uses_dash_placeholder(self):
+        action, sid, _ = cs._normalize_argv(["explain"])
+        assert (action, sid) == ("explain", "-")
+
+    def test_single_unknown_positional_is_session_id(self):
+        action, sid, remaining = cs._normalize_argv(["abc123"])
+        assert (action, sid) == ("graph", "abc123")
+        assert remaining == []
+
+    def test_session_then_action(self):
+        action, sid, remaining = cs._normalize_argv(["abc123", "export", "-o", "f.md"])
+        assert action == "export"
+        assert sid == "abc123"
+        assert remaining == ["-o", "f.md"]
+
+    def test_unknown_action_exits(self, capsys):
+        with pytest.raises(SystemExit) as ei:
+            cs._normalize_argv(["abc123", "bogus"])
+        assert ei.value.code == 1
+        assert "Unknown action 'bogus'" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# parse_args — version/help exits, session validation, graph parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_version_flag_exits_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["context-stats", "--version"])
+        with pytest.raises(SystemExit) as ei:
+            cs.parse_args()
+        assert ei.value.code == 0
+        assert f"context-stats {__version__}" in capsys.readouterr().out
+
+    def test_short_version_flag(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["context-stats", "-V"])
+        with pytest.raises(SystemExit):
+            cs.parse_args()
+        assert __version__ in capsys.readouterr().out
+
+    @pytest.mark.parametrize("help_argv", [[], ["--help"], ["-h"]])
+    def test_help_paths_exit_zero(self, monkeypatch, capsys, help_argv):
+        monkeypatch.setattr(sys, "argv", ["context-stats", *help_argv])
+        with pytest.raises(SystemExit) as ei:
+            cs.parse_args()
+        assert ei.value.code == 0
+        assert "Context Stats Visualizer" in capsys.readouterr().out
+
+    def test_graph_action_parsed(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["context-stats", "abc", "graph", "--type", "tps"])
+        args = cs.parse_args()
+        assert args.action == "graph"
+        assert args.session_id == "abc"
+        assert args.type == "tps"
+
+    def test_graph_help_flag_prints_and_exits(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["context-stats", "graph", "--help"])
+        with pytest.raises(SystemExit) as ei:
+            cs.parse_args()
+        assert ei.value.code == 0
+        assert "context-stats graph" in capsys.readouterr().out
+
+    def test_invalid_session_id_rejected(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["context-stats", "../evil", "graph"])
+        with pytest.raises(SystemExit) as ei:
+            cs.parse_args()
+        assert ei.value.code == 1
+        assert "Error:" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "argv,action,sid",
+        [
+            (["export"], "export", None),
+            (["abc", "export"], "export", "abc"),
+            (["explain"], "explain", "-"),
+            (["report"], "report", None),
+            (["sessions"], "sessions", None),
+            (["abc", "cache-warm", "on"], "cache-warm", "abc"),
+        ],
+    )
+    def test_non_graph_actions_return_minimal_namespace(self, monkeypatch, argv, action, sid):
+        monkeypatch.setattr(sys, "argv", ["context-stats", *argv])
+        args = cs.parse_args()
+        assert args.action == action
+        assert args.session_id == sid
+
+
+# ---------------------------------------------------------------------------
+# render_once — insufficient-data and header/activity branches
+# ---------------------------------------------------------------------------
+
+
+class TestRenderOnceEdges:
+    def test_insufficient_data_watch_mode_returns_message(self, isolated):
+        sf = _write_state([_entry()])
+        result = cs.render_once(sf, "delta", _FakeRenderer(), _Colors(), watch_mode=True)
+        assert isinstance(result, str)
+        assert "Need at least 2 data points" in result
+
+    def test_insufficient_data_non_watch_prints_and_returns_false(self, isolated, capsys):
+        sf = _write_state([])
+        assert cs.render_once(sf, "delta", _FakeRenderer(), _Colors()) is False
+        assert "Need at least 2 data points" in capsys.readouterr().out
+
+    def test_header_without_project_dir_uses_session_label(self, isolated, tmp_path):
+        entries = [
+            _entry(workspace_project_dir="", timestamp=1),
+            _entry(workspace_project_dir="", timestamp=2),
+        ]
+        sf = _write_state(entries)
+        renderer = _FakeRenderer(buffer="S")
+        result = cs.render_once(
+            sf, "delta", renderer, _Colors(), watch_mode=True, config=_Config()
+        )
+        assert "(Session: sess-cli)" in result
+        assert "S" in result
+
+    def test_active_session_shows_waiting_text(self, isolated):
+        now_ts = int(cs.time.time())
+        entries = [
+            _entry(timestamp=now_ts - 5),
+            _entry(timestamp=now_ts - 2),
+        ]
+        sf = _write_state(entries)
+        result = cs.render_once(
+            sf, "delta", _FakeRenderer(buffer=""), _Colors(), watch_mode=True, config=_Config()
+        )
+        # Last entry within is_active's 30s window → rotating waiting text shown.
+        assert "Working..." in result  # reduced_motion=True static text
+
+    def test_compaction_events_render_mi_markers(self, isolated):
+        entries = [
+            _entry(current_input_tokens=190_000, timestamp=1),
+            _entry(current_input_tokens=10_000, timestamp=2),
+            _entry(current_input_tokens=12_000, timestamp=3),
+        ]
+        sf = _write_state(entries)
+        renderer = _FakeRenderer(buffer="")
+        result = cs.render_once(
+            sf, "delta", renderer, _Colors(), watch_mode=True, config=_Config()
+        )
+        assert isinstance(result, str)
+
+
+class _FakeRenderer:
+    """Minimal GraphRenderer double for render_once tests."""
+
+    def __init__(self, buffer: str = "") -> None:
+        self._buffer = buffer
+
+    def begin_buffering(self) -> None:
+        pass
+
+    def get_buffer(self) -> str:
+        return self._buffer
+
+    def render_timeseries(self, *args, **kwargs) -> None:
+        pass
+
+    def render_summary(self, *args, **kwargs) -> None:
+        pass
+
+    def render_footer(self, *args, **kwargs) -> None:
+        pass
+
+
+class _Colors:
+    bold = magenta = dim = cyan = yellow = green = blue = red = reset = ""
+
+
+class _Config:
+    reduced_motion = True
+    compaction_drop_threshold = 0.5
+    compact_mi_warn_threshold = 0.3
+    mi_curve_beta = 1.0
+
+
+# ---------------------------------------------------------------------------
+# watch mode + waiting messages
+# ---------------------------------------------------------------------------
+
+
+class TestWatchMode:
+    def test_one_watch_iteration_without_state_file(self, isolated, monkeypatch, capsys):
+        """Empty state dir → waiting message branch; sleep raises to stop the loop."""
+        monkeypatch.setattr(cs.time, "sleep", lambda _s: (_ for _ in ()).throw(KeyboardInterrupt()))
+        sf = StateFile(None)
+        renderer = _FakeRenderer()
+        with pytest.raises(KeyboardInterrupt):
+            cs.run_watch_mode(sf, "delta", 2, renderer, _Colors(), config=_Config())
+        out = capsys.readouterr().out
+        assert "LIVE" in out
+        assert "no data has been recorded yet" in out
+
+    def test_one_watch_iteration_with_state_file(self, isolated, monkeypatch, capsys):
+        entries = [_entry(timestamp=1), _entry(timestamp=2)]
+        _write_state(entries)
+        monkeypatch.setattr(cs.time, "sleep", lambda _s: (_ for _ in ()).throw(KeyboardInterrupt()))
+        sf = StateFile("sess-cli")
+        renderer = _FakeRenderer(buffer="GRAPH")
+        with pytest.raises(KeyboardInterrupt):
+            cs.run_watch_mode(sf, "delta", 2, renderer, _Colors(), config=_Config())
+        assert "LIVE" in capsys.readouterr().out
+
+
+class TestWaitingMessages:
+    def test_format_waiting_message_with_session(self):
+        msg = cs._format_waiting_message(_Colors(), "sess-9")
+        assert "(Session: sess-9)" in msg
+        assert "Waiting for session data" in msg
+
+    def test_format_waiting_message_without_session(self):
+        msg = cs._format_waiting_message(_Colors(), None)
+        assert "Context Stats" in msg
+        assert "(Session:" not in msg
+
+    def test_show_waiting_message_prints(self, capsys):
+        cs.show_waiting_message(_Colors(), "sess-x", message="custom wait")
+        assert "custom wait" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# sessions action — run_sessions listing branches
+# ---------------------------------------------------------------------------
+
+
+class TestRunSessions:
+    def test_no_recent_sessions_prints_tip(self, isolated, capsys):
+        cs.run_sessions(5, _Colors())
+        out = capsys.readouterr().out
+        assert "No sessions found" in out
+        assert "--minutes N" in out
+
+    def test_lists_recent_session_with_metadata(self, isolated, capsys):
+        entry = _entry(current_input_tokens=300_000, cache_creation=500_000, cache_read=400_000)
+        _write_state([entry], session="recent1")
+        cs.run_sessions(5, _Colors())
+        out = capsys.readouterr().out
+        assert "recent1" in out
+        assert "/tmp/proj".split("/")[-1] in out  # project folder name
+        assert "claude-test" in out
+        assert "tokens" in out
+
+    def test_token_display_million_and_kilo_branches(self, isolated, capsys):
+        big = _entry(
+            current_input_tokens=900_000,
+            cache_creation=200_000,
+            cache_read=100_000,  # current_used = 1.2M
+        )
+        mid = _entry(current_input_tokens=1500)  # current_used = 2600 → K format
+        small = _entry(
+            current_input_tokens=10, cache_creation=0, cache_read=0
+        )  # current_used = 10 → plain count
+        _write_state([big], session="bigses")
+        _write_state([mid], session="midses")
+        _write_state([small], session="smallses")
+        cs.run_sessions(60, _Colors())
+        out = capsys.readouterr().out
+        assert "1.2M tokens" in out
+        assert "3K tokens" in out
+        assert "10 tokens" in out
+
+
+# ---------------------------------------------------------------------------
+# main() — explain / export / cache-warm / report / sessions dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMainDispatch:
+    def test_explain_valid_json_calls_run_explain(self, isolated, monkeypatch, capsys):
+        recorded = {}
+        from claude_statusline.cli import explain as explain_mod
+
+        monkeypatch.setattr(
+            explain_mod, "run_explain", lambda data, no_color: recorded.update(data=data, nc=no_color)
+        )
+        monkeypatch.setattr(sys, "stdin", io.StringIO('{"model":{"display_name":"Opus"}}'))
+        _run_main(monkeypatch, ["explain"])
+        assert recorded["data"] == {"model": {"display_name": "Opus"}}
+        assert recorded["nc"] is False
+
+    def test_explain_invalid_json_errors(self, isolated, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("{not json"))
+        with pytest.raises(SystemExit) as ei:
+            _run_main(monkeypatch, ["explain"])
+        assert ei.value.code == 1
+        assert "invalid JSON on stdin" in capsys.readouterr().err
+
+    def test_export_dispatch_passes_argv(self, isolated, monkeypatch):
+        recorded = {}
+        from claude_statusline.cli import export as export_mod
+
+        monkeypatch.setattr(export_mod, "run_export", lambda argv: recorded.update(argv=argv))
+        _run_main(monkeypatch, ["abc", "export", "--output", "r.md"])
+        assert recorded["argv"] == ["abc", "--output", "r.md"]
+
+    def test_cache_warm_requires_resolvable_session(self, isolated, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as ei:
+            _run_main(monkeypatch, ["cache-warm", "on"])
+        assert ei.value.code == 1
+        assert "No session data found" in capsys.readouterr().err
+
+    def test_cache_warm_dispatch_with_latest_session(self, isolated, monkeypatch):
+        _write_state([_entry()], session="warmme")
+        recorded = {}
+        from claude_statusline.cli import cache_warm as cw_mod
+
+        monkeypatch.setattr(
+            cw_mod,
+            "run_cache_warm",
+            lambda sid, remaining, colors: recorded.update(sid=sid, remaining=remaining),
+        )
+        _run_main(monkeypatch, ["cache-warm", "on"])
+        assert recorded["sid"] == "warmme"
+        assert recorded["remaining"] == ["on"]
+
+    def test_report_dispatch(self, isolated, monkeypatch):
+        recorded = {}
+        from claude_statusline.cli import report as report_mod
+
+        monkeypatch.setattr(report_mod, "run_report", lambda remaining: recorded.update(rem=remaining))
+        _run_main(monkeypatch, ["report", "--since-days", "7"])
+        assert recorded["rem"] == ["--since-days", "7"]
+
+    def test_sessions_rejects_session_id(self, isolated, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as ei:
+            _run_main(monkeypatch, ["abc", "sessions"])
+        assert ei.value.code == 1
+        assert "does not accept a session_id" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "argv,err_fragment",
+        [
+            (["sessions", "--minutes"], "requires a value"),
+            (["sessions", "--minutes", "abc"], "Invalid value for --minutes"),
+            (["sessions", "--minutes", "0"], "must be a positive integer"),
+            (["sessions", "--bogus"], "Unknown flag for sessions"),
+            (["sessions", "extra-positional"], "Unexpected argument for sessions"),
+        ],
+    )
+    def test_sessions_argument_errors(self, isolated, monkeypatch, capsys, argv, err_fragment):
+        with pytest.raises(SystemExit) as ei:
+            _run_main(monkeypatch, argv)
+        assert ei.value.code == 1
+        assert err_fragment in capsys.readouterr().err
+
+    def test_sessions_accepts_minutes_flag(self, isolated, monkeypatch):
+        recorded = {}
+        monkeypatch.setattr(cs, "run_sessions", lambda minutes, colors: recorded.update(m=minutes))
+        _run_main(monkeypatch, ["sessions", "--minutes", "30"])
+        assert recorded["m"] == 30
+
+    def test_sessions_ignores_no_color_flag(self, isolated, monkeypatch):
+        recorded = {}
+        monkeypatch.setattr(cs, "run_sessions", lambda minutes, colors: recorded.update(m=minutes))
+        _run_main(monkeypatch, ["sessions", "--no-color"])
+        assert recorded["m"] == 5  # default window preserved
+
+
+# ---------------------------------------------------------------------------
+# main() — graph default flow (waiting message / insufficient data exits)
+# ---------------------------------------------------------------------------
+
+
+class TestMainGraphFlow:
+    def test_graph_no_state_no_watch_shows_waiting_for_named_session(
+        self, isolated, monkeypatch, capsys
+    ):
+        with pytest.raises(SystemExit) as ei:
+            _run_main(monkeypatch, ["ghost-sess", "graph", "--no-watch"])
+        assert ei.value.code == 0
+        out = capsys.readouterr().out
+        assert "(Session: ghost-sess)" in out
+
+    def test_graph_no_state_no_watch_without_session(self, isolated, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as ei:
+            _run_main(monkeypatch, ["graph", "--no-watch"])
+        assert ei.value.code == 0
+        out = capsys.readouterr().out
+        assert "No session data found." in out
+
+    def test_graph_existing_file_insufficient_data_exits_nonzero(
+        self, isolated, monkeypatch, capsys
+    ):
+        _write_state([_entry()])
+        with pytest.raises(SystemExit) as ei:
+            _run_main(monkeypatch, ["sess-cli", "graph", "--no-watch"])
+        assert ei.value.code == 1
+        assert "Need at least 2 data points" in capsys.readouterr().out
+
+    def test_graph_full_render_success_path(self, isolated, monkeypatch, capsys):
+        """Two valid entries + --no-watch renders once and exits 0."""
+        entries = [
+            _entry(timestamp=1710288000),
+            _entry(timestamp=1710288060, current_input_tokens=350),
+        ]
+        _write_state(entries)
+        _run_main(monkeypatch, ["sess-cli", "graph", "--no-watch"])
+        assert capsys.readouterr().out  # rendered output reached stdout

--- a/tests/python/test_cli_entry.py
+++ b/tests/python/test_cli_entry.py
@@ -196,9 +196,7 @@ class TestRenderOnceEdges:
         ]
         sf = _write_state(entries)
         renderer = _FakeRenderer(buffer="S")
-        result = cs.render_once(
-            sf, "delta", renderer, _Colors(), watch_mode=True, config=_Config()
-        )
+        result = cs.render_once(sf, "delta", renderer, _Colors(), watch_mode=True, config=_Config())
         assert "(Session: sess-cli)" in result
         assert "S" in result
 
@@ -223,9 +221,7 @@ class TestRenderOnceEdges:
         ]
         sf = _write_state(entries)
         renderer = _FakeRenderer(buffer="")
-        result = cs.render_once(
-            sf, "delta", renderer, _Colors(), watch_mode=True, config=_Config()
-        )
+        result = cs.render_once(sf, "delta", renderer, _Colors(), watch_mode=True, config=_Config())
         assert isinstance(result, str)
 
 
@@ -359,7 +355,9 @@ class TestMainDispatch:
         from claude_statusline.cli import explain as explain_mod
 
         monkeypatch.setattr(
-            explain_mod, "run_explain", lambda data, no_color: recorded.update(data=data, nc=no_color)
+            explain_mod,
+            "run_explain",
+            lambda data, no_color: recorded.update(data=data, nc=no_color),
         )
         monkeypatch.setattr(sys, "stdin", io.StringIO('{"model":{"display_name":"Opus"}}'))
         _run_main(monkeypatch, ["explain"])
@@ -405,7 +403,9 @@ class TestMainDispatch:
         recorded = {}
         from claude_statusline.cli import report as report_mod
 
-        monkeypatch.setattr(report_mod, "run_report", lambda remaining: recorded.update(rem=remaining))
+        monkeypatch.setattr(
+            report_mod, "run_report", lambda remaining: recorded.update(rem=remaining)
+        )
         _run_main(monkeypatch, ["report", "--since-days", "7"])
         assert recorded["rem"] == ["--since-days", "7"]
 

--- a/tests/python/test_git_pr_cache.py
+++ b/tests/python/test_git_pr_cache.py
@@ -333,7 +333,10 @@ class TestGetGitInfo:
         cm = ColorManager(enabled=True)
         plain = get_git_info(repo, colors_enabled=False)
         colored = get_git_info(repo, colors_enabled=False, color_manager=cm)
-        assert colored != plain or "\033[" in colored or colored == plain
+        # Manager colors are applied even when the legacy flag says "off".
+        assert "\033[" in colored
+        if "\033[" not in plain:
+            assert colored != plain
 
     def test_rev_parse_failure_returns_empty(self, repo, monkeypatch):
         monkeypatch.setattr(
@@ -382,4 +385,4 @@ class TestGetGitInfo:
         linked.mkdir()
         (linked / ".git").write_text("gitdir: /nonexistent\n")
         # git commands fail cleanly → empty string, no crash (F-BUG-007).
-        assert get_git_info(linked) in ("",) or True
+        assert get_git_info(linked, colors_enabled=False) == ""

--- a/tests/python/test_git_pr_cache.py
+++ b/tests/python/test_git_pr_cache.py
@@ -1,0 +1,385 @@
+"""Tests for _get_pr_number, its TTL caches, and git failure branches
+(issue #138, F-TEST-003).
+
+gh/git subprocesses are stubbed via monkeypatched subprocess.run; the cache
+file lives under tmp_path; time.time is frozen per-test for TTL boundaries.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from claude_statusline.core import git as git_mod
+from claude_statusline.core.git import (
+    _PR_CACHE_NEGATIVE_TTL_SECONDS,
+    _PR_CACHE_TTL_SECONDS,
+    _get_pr_number,
+    _pr_cache_get,
+    _pr_cache_set,
+    get_git_info,
+)
+
+
+@pytest.fixture()
+def cache_file(tmp_path, monkeypatch):
+    """Redirect the shared PR cache into tmp_path."""
+    path = tmp_path / "statusline" / "pr_number_cache.json"
+    monkeypatch.setattr(git_mod, "_pr_cache_file", lambda: path)
+    return path
+
+
+@pytest.fixture()
+def fake_gh(monkeypatch):
+    """Make shutil.which('gh') report an available gh binary."""
+
+    def _enable(path="/usr/bin/gh"):
+        monkeypatch.setattr(git_mod.shutil, "which", lambda name: path if name == "gh" else None)
+
+    return _enable
+
+
+class StubCompleted:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# ---------------------------------------------------------------------------
+# _pr_cache_get / _pr_cache_set — low-level cache behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPrCache:
+    def test_missing_file_is_a_miss(self, cache_file):
+        assert _pr_cache_get("k") is None
+
+    def test_corrupt_json_is_a_miss(self, cache_file):
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text("{not json")
+        assert _pr_cache_get("k") is None
+
+    def test_non_dict_payload_is_a_miss(self, cache_file):
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text(json.dumps(["a", "b"]))
+        assert _pr_cache_get("k") is None
+
+    def test_unexpired_entry_hit(self, cache_file, monkeypatch):
+        monkeypatch.setattr(git_mod.time, "time", lambda: 1000.0)
+        _pr_cache_set("k", "#7", ttl=30)
+        assert _pr_cache_get("k") == "#7"
+
+    def test_expired_entry_miss_at_boundary(self, cache_file, monkeypatch):
+        """exp == now is a miss (hit requires exp strictly > now)."""
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text(json.dumps({"k": {"pr": "#7", "exp": 1000}}))
+        monkeypatch.setattr(git_mod.time, "time", lambda: 1000.0)
+        assert _pr_cache_get("k") is None
+
+    def test_just_before_expiry_hit(self, cache_file, monkeypatch):
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text(json.dumps({"k": {"pr": "#7", "exp": 1000}}))
+        monkeypatch.setattr(git_mod.time, "time", lambda: 999.9)
+        assert _pr_cache_get("k") == "#7"
+
+    def test_set_prunes_expired_entries(self, cache_file, monkeypatch):
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text(
+            json.dumps({"old": {"pr": "#1", "exp": 10}, "live": {"pr": "#2", "exp": 10_000}})
+        )
+        monkeypatch.setattr(git_mod.time, "time", lambda: 100.0)
+        _pr_cache_set("new", "#3")
+        data = json.loads(cache_file.read_text())
+        assert "old" not in data
+        assert data["live"]["pr"] == "#2"
+        assert data["new"]["pr"] == "#3"
+
+    def test_default_ttl_used_when_none_given(self, cache_file, monkeypatch):
+        monkeypatch.setattr(git_mod.time, "time", lambda: 500.0)
+        _pr_cache_set("k", "#9")
+        data = json.loads(cache_file.read_text())
+        assert data["k"]["exp"] == pytest.approx(500.0 + _PR_CACHE_TTL_SECONDS)
+
+    def test_non_dict_entry_values_pruned(self, cache_file, monkeypatch):
+        cache_file.parent.mkdir(parents=True)
+        cache_file.write_text(json.dumps({"junk": "not-a-dict"}))
+        monkeypatch.setattr(git_mod.time, "time", lambda: 100.0)
+        _pr_cache_set("k", "#1")
+        data = json.loads(cache_file.read_text())
+        assert "junk" not in data
+        assert data["k"] == {"pr": "#1", "exp": 100.0 + _PR_CACHE_TTL_SECONDS}
+
+    def test_unwritable_cache_dir_swallows_error(self, tmp_path, monkeypatch):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("i am a file")
+
+        def boom():
+            return blocker / "child" / "cache.json"
+
+        monkeypatch.setattr(git_mod, "_pr_cache_file", boom)
+        _pr_cache_set("k", "#1")  # must not raise
+        assert _pr_cache_get("k") is None
+
+    def test_replace_failure_cleans_temp_and_swallows(self, cache_file, monkeypatch):
+        cache_file.parent.mkdir(parents=True)
+
+        def fail_replace(src, dst):
+            raise OSError("replace denied")
+
+        monkeypatch.setattr(git_mod.os, "replace", fail_replace)
+        _pr_cache_set("k", "#1")  # swallowed
+        leftovers = list(cache_file.parent.glob("*.tmp"))
+        assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# _get_pr_number — lookup flows against stubbed gh/git
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrNumber:
+    def test_gh_absent_returns_empty_without_subprocess(self, cache_file, monkeypatch):
+        monkeypatch.setattr(git_mod.shutil, "which", lambda name: None)
+        called = False
+
+        def guard(*a, **k):
+            nonlocal called
+            called = True
+            return StubCompleted()
+
+        monkeypatch.setattr(git_mod.subprocess, "run", guard)
+        assert _get_pr_number(Path("/proj")) == ""
+        assert called is False
+
+    def _stub_runs(self, monkeypatch, runs):
+        """Patch subprocess.run to pop scripted results in order."""
+        scripted = list(runs)
+        calls = []
+
+        def runner(argv, **kwargs):
+            calls.append(list(argv))
+            if not scripted:
+                raise AssertionError("unexpected extra subprocess.run call")
+            return scripted.pop(0)
+
+        monkeypatch.setattr(git_mod.subprocess, "run", runner)
+        return calls
+
+    def test_branch_lookup_failure_returns_empty(self, cache_file, fake_gh, monkeypatch):
+        self._stub_runs(monkeypatch, [StubCompleted(returncode=1)])
+        assert _get_pr_number(Path("/proj")) == ""
+
+    def test_empty_branch_name_returns_empty(self, cache_file, fake_gh, monkeypatch):
+        self._stub_runs(monkeypatch, [StubCompleted(stdout="\n")])
+        assert _get_pr_number(Path("/proj")) == ""
+
+    def test_pr_found_formats_hash_prefix_and_caches_positive(
+        self, cache_file, fake_gh, monkeypatch
+    ):
+        calls = self._stub_runs(
+            monkeypatch,
+            [
+                StubCompleted(stdout="feature\n"),
+                StubCompleted(stdout='[{"number": 42}]'),
+                StubCompleted(stdout="feature\n"),  # branch re-resolved on 2nd call
+            ],
+        )
+        monkeypatch.setattr(git_mod.time, "time", lambda: 100.0)
+        assert _get_pr_number(Path("/proj")) == "#42"
+        # gh was invoked exactly once; second call served from cache.
+        cached = json.loads(cache_file.read_text())
+        key = next(iter(cached))
+        assert "/proj" in key and "feature" in key
+        assert cached[key]["pr"] == "#42"
+        assert cached[key]["exp"] == pytest.approx(100.0 + _PR_CACHE_TTL_SECONDS)
+        assert sum(1 for c in calls if c[0] == "gh") == 1
+        assert _get_pr_number(Path("/proj")) == "#42"
+        assert sum(1 for c in calls if c[0] == "gh") == 1
+
+    def test_no_open_pr_caches_empty_positive(self, cache_file, fake_gh, monkeypatch):
+        self._stub_runs(
+            monkeypatch,
+            [
+                StubCompleted(stdout="main\n"),
+                StubCompleted(stdout="[]"),
+            ],
+        )
+        monkeypatch.setattr(git_mod.time, "time", lambda: 100.0)
+        assert _get_pr_number(Path("/proj")) == ""
+        data = json.loads(cache_file.read_text())
+        entry = next(iter(data.values()))
+        assert entry["pr"] == ""
+        assert entry["exp"] == pytest.approx(100.0 + _PR_CACHE_TTL_SECONDS)
+
+    def test_malformed_gh_output_negatively_cached(self, cache_file, fake_gh, monkeypatch):
+        self._stub_runs(
+            monkeypatch,
+            [
+                StubCompleted(stdout="dev\n"),
+                StubCompleted(stdout="<html>oops"),
+            ],
+        )
+        monkeypatch.setattr(git_mod.time, "time", lambda: 100.0)
+        assert _get_pr_number(Path("/proj")) == ""
+        entry = next(iter(json.loads(cache_file.read_text()).values()))
+        assert entry["pr"] == ""
+        assert entry["exp"] == pytest.approx(100.0 + _PR_CACHE_NEGATIVE_TTL_SECONDS)
+
+    def test_gh_failure_negatively_cached_then_recovered_after_expiry(
+        self, cache_file, fake_gh, monkeypatch
+    ):
+        clock = {"now": 100.0}
+        monkeypatch.setattr(git_mod.time, "time", lambda: clock["now"])
+        self._stub_runs(
+            monkeypatch,
+            [
+                StubCompleted(stdout="dev\n"),
+                StubCompleted(returncode=1, stderr="auth expired"),
+                StubCompleted(stdout="dev\n"),  # 2nd call: branch re-resolved, negative hit
+                StubCompleted(stdout="dev\n"),  # 3rd call after expiry: branch again
+                StubCompleted(stdout='[{"number": 5}]'),
+            ],
+        )
+        assert _get_pr_number(Path("/proj")) == ""  # failure, negative-cached
+        assert _get_pr_number(Path("/proj")) == ""  # still inside negative TTL
+        clock["now"] += _PR_CACHE_NEGATIVE_TTL_SECONDS + 1  # expire the negative entry
+        assert _get_pr_number(Path("/proj")) == "#5"
+
+    def test_branch_timeout_negatively_cached_when_key_known(self, cache_file, fake_gh, monkeypatch):
+        """Timeout on the *gh* leg (branch already resolved) → negative cache."""
+        def runner(argv, **kwargs):
+            if argv[0] == "git":
+                return StubCompleted(stdout="dev\n")
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=5)
+
+        monkeypatch.setattr(git_mod.subprocess, "run", runner)
+        monkeypatch.setattr(git_mod.time, "time", lambda: 100.0)
+        assert _get_pr_number(Path("/proj")) == ""
+        entry = next(iter(json.loads(cache_file.read_text()).values()))
+        assert entry["exp"] == pytest.approx(100.0 + _PR_CACHE_NEGATIVE_TTL_SECONDS)
+
+    def test_branch_timeout_before_key_leaves_no_cache(self, cache_file, fake_gh, monkeypatch):
+        def runner(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+        monkeypatch.setattr(git_mod.subprocess, "run", runner)
+        assert _get_pr_number(Path("/proj")) == ""
+        assert not cache_file.exists()
+
+    def test_oserror_on_gh_negatively_cached(self, cache_file, fake_gh, monkeypatch):
+        def runner(argv, **kwargs):
+            if argv[0] == "git":
+                return StubCompleted(stdout="dev\n")
+            raise OSError("spawn failed")
+
+        monkeypatch.setattr(git_mod.subprocess, "run", runner)
+        monkeypatch.setattr(git_mod.time, "time", lambda: 100.0)
+        assert _get_pr_number(Path("/proj")) == ""
+        assert cache_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# get_git_info — failure branches and formatting variants
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """A real git repo with one commit and one untracked change."""
+    import subprocess as sp
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    env_vars = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@example.com",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@example.com",
+    }
+    import os
+
+    env = {**os.environ, **env_vars}
+    sp.run(["git", "init", "-q"], cwd=workdir, check=True, env=env)
+    (workdir / "tracked.txt").write_text("hello\n")
+    sp.run(["git", "add", "."], cwd=workdir, check=True, env=env)
+    sp.run(["git", "commit", "-qm", "init"], cwd=workdir, check=True, env=env)
+    return workdir
+
+
+class TestGetGitInfo:
+    def test_not_a_repo_returns_empty(self, tmp_path):
+        empty = tmp_path / "plain"
+        empty.mkdir()
+        assert get_git_info(empty) == ""
+
+    def test_real_repo_clean_shows_branch_only(self, repo):
+        out = get_git_info(repo, colors_enabled=False)
+        assert out.startswith(" | ")
+        assert "[" not in out
+
+    def test_real_repo_dirty_shows_change_count(self, repo):
+        (repo / "tracked.txt").write_text("changed\n")
+        (repo / "new.txt").write_text("x\n")
+        out = get_git_info(repo, colors_enabled=False)
+        assert "[2]" in out
+
+    def test_color_manager_overrides_constants(self, repo):
+        from claude_statusline.core.colors import ColorManager
+
+        cm = ColorManager(enabled=True)
+        plain = get_git_info(repo, colors_enabled=False)
+        colored = get_git_info(repo, colors_enabled=False, color_manager=cm)
+        assert colored != plain or "\033[" in colored or colored == plain
+
+    def test_rev_parse_failure_returns_empty(self, repo, monkeypatch):
+        monkeypatch.setattr(
+            git_mod.subprocess,
+            "run",
+            lambda *a, **k: StubCompleted(returncode=128),
+        )
+        assert get_git_info(repo) == ""
+
+    def test_empty_branch_name_returns_empty(self, repo, monkeypatch):
+        monkeypatch.setattr(
+            git_mod.subprocess,
+            "run",
+            lambda *a, **k: StubCompleted(stdout="\n"),
+        )
+        assert get_git_info(repo) == ""
+
+    def test_status_failure_counts_zero_changes(self, repo, monkeypatch):
+        def runner(argv, **kwargs):
+            if "status" in argv:
+                return StubCompleted(returncode=128)
+            return StubCompleted(stdout="main\n")
+
+        monkeypatch.setattr(git_mod.subprocess, "run", runner)
+        out = get_git_info(repo, colors_enabled=False)
+        assert "main" in out
+        assert "[" not in out
+
+    def test_timeout_degrades_to_empty(self, repo, monkeypatch):
+        def runner(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+        monkeypatch.setattr(git_mod.subprocess, "run", runner)
+        assert get_git_info(repo) == ""
+
+    def test_oserror_degrades_to_empty(self, repo, monkeypatch):
+        def runner(*a, **k):
+            raise OSError("no git binary")
+
+        monkeypatch.setattr(git_mod.subprocess, "run", runner)
+        assert get_git_info(repo) == ""
+
+    def test_worktree_style_git_file_accepted(self, repo, tmp_path):
+        """``.git`` as a pointer file (worktree/submodule) is still probed."""
+        linked = tmp_path / "wt"
+        linked.mkdir()
+        (linked / ".git").write_text("gitdir: /nonexistent\n")
+        # git commands fail cleanly → empty string, no crash (F-BUG-007).
+        assert get_git_info(linked) in ("",) or True

--- a/tests/python/test_git_pr_cache.py
+++ b/tests/python/test_git_pr_cache.py
@@ -249,8 +249,11 @@ class TestGetPrNumber:
         clock["now"] += _PR_CACHE_NEGATIVE_TTL_SECONDS + 1  # expire the negative entry
         assert _get_pr_number(Path("/proj")) == "#5"
 
-    def test_branch_timeout_negatively_cached_when_key_known(self, cache_file, fake_gh, monkeypatch):
+    def test_branch_timeout_negatively_cached_when_key_known(
+        self, cache_file, fake_gh, monkeypatch
+    ):
         """Timeout on the *gh* leg (branch already resolved) → negative cache."""
+
         def runner(argv, **kwargs):
             if argv[0] == "git":
                 return StubCompleted(stdout="dev\n")

--- a/tests/python/test_git_pr_cache.py
+++ b/tests/python/test_git_pr_cache.py
@@ -193,7 +193,8 @@ class TestGetPrNumber:
         # gh was invoked exactly once; second call served from cache.
         cached = json.loads(cache_file.read_text())
         key = next(iter(cached))
-        assert "/proj" in key and "feature" in key
+        # str(project_dir) is platform-normalized (\proj on Windows).
+        assert key == f"{Path('/proj')}\tfeature"
         assert cached[key]["pr"] == "#42"
         assert cached[key]["exp"] == pytest.approx(100.0 + _PR_CACHE_TTL_SECONDS)
         assert sum(1 for c in calls if c[0] == "gh") == 1

--- a/tests/python/test_report.py
+++ b/tests/python/test_report.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta
 
 import pytest
 
+import claude_statusline.analytics as analytics_mod
+import claude_statusline.cli.report as report_mod
 from claude_statusline.analytics import (
     ProjectStats,
     SessionStats,
@@ -11,12 +13,38 @@ from claude_statusline.analytics import (
 )
 from claude_statusline.cli.report import generate_report
 
+# Frozen clock shared by every datetime.now() read in this module (F-TEST-008).
+# The fixture below swaps it into both modules that read the wall clock, so a
+# midnight straddle during a CI run can no longer split two reads across days.
+_FROZEN_NOW = datetime(2026, 6, 15, 12, 0, 0)
+
+
+class _FrozenDatetime(datetime):
+    """datetime stand-in whose now() always returns _FROZEN_NOW.
+
+    Everything else (fromtimestamp, strftime via instances) delegates to the
+    real implementation because it subclasses datetime.
+    """
+
+    @classmethod
+    def now(cls, tz=None):  # noqa: N802 - mirrors datetime API
+        if tz is not None:
+            return _FROZEN_NOW.replace(tzinfo=tz)
+        return _FROZEN_NOW
+
+
+@pytest.fixture(autouse=True)
+def frozen_report_clock(monkeypatch):
+    """Pin datetime.now() in report and analytics to _FROZEN_NOW."""
+    monkeypatch.setattr(report_mod, "datetime", _FrozenDatetime)
+    monkeypatch.setattr(analytics_mod, "datetime", _FrozenDatetime)
+
 
 def _make_session(
     session_id, start_offset_days=0, end_offset_days=0, project_dir="/home/user/proj"
 ):
-    """Return a SessionStats with start/end times relative to now."""
-    now = int(datetime.now().timestamp())
+    """Return a SessionStats with start/end times relative to the frozen clock."""
+    now = int(_FROZEN_NOW.timestamp())
     start = now - int(start_offset_days * 86400)
     end = now - int(end_offset_days * 86400)
     return SessionStats(
@@ -156,7 +184,8 @@ def test_report_period_with_since_days():
     since_days = 7
     report = generate_report([project], since_days=since_days)
 
-    expected_start = (datetime.now() - timedelta(days=since_days)).strftime("%Y-%m-%d")
+    # Same frozen clock the report reads — no independent live read (F-TEST-008).
+    expected_start = (_FROZEN_NOW - timedelta(days=since_days)).strftime("%Y-%m-%d")
     assert expected_start in report
     # The old session start date (2023) must NOT appear as the period start
     assert "2023-11-14" not in report.split("Period:")[1].split("\n")[0]

--- a/tests/python/test_tokens_format.py
+++ b/tests/python/test_tokens_format.py
@@ -88,9 +88,7 @@ class TestCalculateContextUsage:
 
     def test_autocompact_disabled_branch_skips_buffer(self):
         """Disabled autocompact frees the whole remainder — no buffer carve-out."""
-        free, pct, buf = calculate_context_usage(
-            100_000, 200_000, autocompact_enabled=False
-        )
+        free, pct, buf = calculate_context_usage(100_000, 200_000, autocompact_enabled=False)
         assert buf == 45_000  # buffer still reported…
         assert free == 100_000  # …but not subtracted
         assert pct == pytest.approx(50.0)
@@ -102,8 +100,6 @@ class TestCalculateContextUsage:
         assert pct == 0.0
 
     def test_disabled_overrun_also_clamps(self):
-        free, pct, _ = calculate_context_usage(
-            250_000, 200_000, autocompact_enabled=False
-        )
+        free, pct, _ = calculate_context_usage(250_000, 200_000, autocompact_enabled=False)
         assert free == 0
         assert pct == 0.0

--- a/tests/python/test_tokens_format.py
+++ b/tests/python/test_tokens_format.py
@@ -1,0 +1,109 @@
+"""Table-driven edge-case tests for formatters/tokens.py
+(issue #140, F-TEST-007).
+
+Covers the zero/negative size guard, the autocompact-disabled branch, and the
+clamping path in calculate_context_usage, plus abbreviation boundaries in
+format_tokens and decimals handling in format_percentage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_statusline.formatters.tokens import (
+    calculate_context_usage,
+    format_percentage,
+    format_tokens,
+)
+
+
+class TestFormatTokens:
+    @pytest.mark.parametrize(
+        "count,expected",
+        [
+            (0, "0"),
+            (1, "1"),
+            (42, "42"),
+            (999, "999"),
+            (1_000, "1,000"),
+            (64_000, "64,000"),
+            (1_000_000, "1,000,000"),
+            (-5_000, "-5,000"),
+        ],
+    )
+    def test_detail_mode_exact_with_commas(self, count, expected):
+        assert format_tokens(count, detail=True) == expected
+
+    @pytest.mark.parametrize(
+        "count,expected",
+        [
+            (0, "0"),
+            (1, "1"),
+            (999, "999"),  # below k boundary stays plain
+            (1_000, "1.0k"),  # exact k boundary abbreviates
+            (1_500, "1.5k"),
+            (999_999, "1000.0k"),  # still below 1M
+            (1_000_000, "1.0M"),  # exact M boundary
+            (2_500_000, "2.5M"),
+            (-5_000, "-5000"),  # negatives fall through to str()
+        ],
+    )
+    def test_abbreviated_mode_boundaries(self, count, expected):
+        assert format_tokens(count, detail=False) == expected
+
+
+class TestFormatPercentage:
+    @pytest.mark.parametrize(
+        "value,decimals,expected",
+        [
+            (0.0, 1, "0.0%"),
+            (75.5, 1, "75.5%"),
+            (100.0, 0, "100%"),
+            (33.3333, 3, "33.333%"),
+            (-12.5, 2, "-12.50%"),
+        ],
+    )
+    def test_decimals_handling(self, value, decimals, expected):
+        assert format_percentage(value, decimals=decimals) == expected
+
+    def test_default_is_one_decimal(self):
+        assert format_percentage(41.25) == "41.2%"
+
+
+class TestCalculateContextUsage:
+    @pytest.mark.parametrize("total_size", [0, -200_000])
+    def test_non_positive_total_guard(self, total_size):
+        """Zero/negative window short-circuits to all-zero stats."""
+        assert calculate_context_usage(50_000, total_size) == (0, 0.0, 0)
+
+    def test_autocompact_enabled_default_ratio(self):
+        free, pct, buf = calculate_context_usage(100_000, 200_000)
+        assert buf == 45_000  # int(200k * 0.225)
+        assert free == 55_000
+        assert pct == pytest.approx(27.5)
+
+    def test_custom_ratio(self):
+        _, _, buf = calculate_context_usage(0, 100_000, autocompact_ratio=0.5)
+        assert buf == 50_000
+
+    def test_autocompact_disabled_branch_skips_buffer(self):
+        """Disabled autocompact frees the whole remainder — no buffer carve-out."""
+        free, pct, buf = calculate_context_usage(
+            100_000, 200_000, autocompact_enabled=False
+        )
+        assert buf == 45_000  # buffer still reported…
+        assert free == 100_000  # …but not subtracted
+        assert pct == pytest.approx(50.0)
+
+    def test_overrun_clamps_free_to_zero(self):
+        """used beyond the effective ceiling clamps to 0, never negative."""
+        free, pct, _ = calculate_context_usage(300_000, 200_000)
+        assert free == 0
+        assert pct == 0.0
+
+    def test_disabled_overrun_also_clamps(self):
+        free, pct, _ = calculate_context_usage(
+            250_000, 200_000, autocompact_enabled=False
+        )
+        assert free == 0
+        assert pct == 0.0


### PR DESCRIPTION
Closes #137

Closes #138

Closes #139

Closes #140

## Summary

Phase-P3 coverage sprint (batch of four test-only tasks): adds 150 unit tests across five new/updated test modules closing findings F-TEST-002, F-TEST-003, F-TEST-004, F-TEST-005, F-TEST-007 and F-TEST-008. No product behavior changed — every diff line lives under `tests/python/`.

## Approach

Balanced option: one focused test module per issue scope plus a frozen-clock fix in `test_report.py`, reusing the established fixture patterns (`state_dirs` monkeypatching, fake-gh/git `subprocess.run` stubs, tmp_path fault injection) from `test_state_robustness.py` / `test_tps_trend.py` so the parity suite from #176 stays untouched.

## Decision Record

- **Root cause:** CLI main-dispatch/argument-fallback paths, the PR-number lookup with its 60s/10s TTL caches, git timeout/OSError recovery branches, state corruption/IO-failure recovery, the analytics aggregation engine, and the tokens.py edge branches were untested; `test_report.py` read the wall clock independently in fixtures and assertions, straddling midnight on slow CI runners.
- **Options considered:** Option 1 — append tests to existing files only; Option 2 — per-issue focused test modules + frozen-time fix; Option 3 — also cover explain.py/export.py gaps
- **Options rejected:** Option 1 — cannot reach the cli ≥85% / analytics ≥80% targets coherently; Option 3 — out of scope for these four issues (owned by other P3 tasks)
- **Selected option:** Option 2 — per-issue focused test suites + frozen-time fix
- **Residual risk:** none identified — all named module targets exceeded; parity suite green throughout
- **Design-confirm:** auto-selected Option 2 (complexity: high)

Analyzed at: `test/137-coverage-sprint @ 4e22d52` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `tests/python/test_cli_entry.py` | new — 52 in-process tests: _normalize_argv fallbacks, parse_args version/help/validation exits, render_once edge branches, watch-mode single iteration, waiting messages, sessions listing branches, full main() dispatch incl. error exits (#137, F-TEST-002) |
| `tests/python/test_git_pr_cache.py` | new — 31 tests: PR-cache hit/expiry at TTL boundaries, prune/corruption/write-failure handling, _get_pr_number found/absent/malformed/negative-TTL/timeout/OSError flows, get_git_info failure branches + real-repo happy path (#138, F-TEST-003) |
| `tests/python/test_analytics_units.py` | new — 37 tests: SessionStats/ProjectStats math and families, _load_session_stats malformed/empty/unreadable, grouping + since_days filtering, load_all_projects sorting/discovery, state IO-failure fault injection (read/append/rotate OSError, flock guards, rollback cleanup), list_sessions, safe_int/safe_float fallbacks (#139, F-TEST-004/F-TEST-005) |
| `tests/python/test_tokens_format.py` | new — 30 table-driven cases: format_tokens detail/abbrev boundaries incl. zero/negative, format_percentage decimals, calculate_context_usage zero/negative-size guard, autocompact-disabled branch, overrun clamping (#140, F-TEST-007) |
| `tests/python/test_report.py` | modified — autouse fixture pins `datetime.now()` in both `cli.report` and `analytics` to a shared frozen clock; fixtures and assertions derive offsets from the same clock; no live reads remain (#140, F-TEST-008) |

No bugs found — zero product-code changes required.

## Test Results

- Unit tests: 1319 passed (was 1169; +150 new)
- Integration tests: included above (parity suite 425 tests green)
- E2e tests: none defined
- Build: passed (ruff clean, mypy clean)
- QA cycles: 1

Coverage vs targets:

| Module | Before | After | Target |
|--------|--------|-------|--------|
| `src/claude_statusline` overall | 77.35% | **87.59%** | ≥80% ✓ |
| `cli/context_stats.py` | 54% | **98%** | ≥85% ✓ |
| `core/git.py` | 85% | **97%** | ≥90% ✓ |
| `core/state.py` | 86% | **99%** | — |
| `analytics.py` | 63% | **100%** | ≥80% ✓ |
| `formatters/tokens.py` | 62% | **100%** | — |

Flake check: `for i in $(seq 1 20); do pytest tests/python/test_report.py -q; done` → 0 failures across 20 consecutive runs.

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| #137: `cli/context_stats.py` coverage ≥85%; argument-fallback and subcommand-dispatch error paths exercised | pass | 98% measured via `pytest --cov=claude_statusline.cli.context_stats`; `test_cli_entry.py` covers unknown-action exit, invalid session_id exit, sessions argument errors, explain bad-JSON exit |
| #137/#140: overall `src/claude_statusline` ≥80%; command of record passes | pass | 87.59% overall, 1319 passed via `source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider --cov=src/claude_statusline` |
| #138: `core/git.py` ≥90% incl. _get_pr_number, cache hit/expiry, timeout/OSError | pass | 97%; `TestGetPrNumber` covers positive/negative TTL boundaries, malformed gh output, branch failures, TimeoutExpired/OSError injection |
| #139: corruption/IO-failure branches of `core/state.py`; `analytics.py` ≥80% | pass | 99%/100%; `TestStateIoFailures` + `TestLoadSessionStats` fault-injection on tmp_path |
| #140: table-driven tokens.py branch tests; `test_report.py` frozen time | pass | `test_tokens_format.py` (30 cases); no live `datetime.now()` left in `test_report.py`; 20× repeat run green |

<!-- gitissue:qa v1 head=4e22d524fc68d9b7c11f8446521e97b967a303ca profile=full cycles=1 review=clean tests=1319@4e22d524fc68d9b7c11f8446521e97b967a303ca ui=none:none@4e22d524fc68d9b7c11f8446521e97b967a303ca -->
