### PR TITLE
chore(ci): raise coverage gate to 84% (#141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,12 @@ jobs:
           # C extension tracer and Windows process shutdown. We capture the result,
           # and on Windows only, treat exit code 1 as success when no tests failed.
           set +e
-          # Coverage floor (--cov-fail-under=73) is inherited from
-          # pyproject.toml [tool.pytest.ini_options] addopts (issue #117), so
-          # the measured scope here must match the pinned scope:
-          # src/claude_statusline (73.78% precise on main). The previous
-          # scripts+src scope measures 66% and would trip that floor on every
-          # matrix leg.
+          # Coverage floor (--cov-fail-under=84) is inherited from
+          # pyproject.toml [tool.pytest.ini_options] addopts (issue #117,
+          # raised to 84 by issue #141), so the measured scope here must
+          # match the pinned scope: src/claude_statusline (87.59% precise
+          # when the floor was raised). The previous scripts+src scope
+          # measures lower and would trip that floor on every matrix leg.
           pytest tests/python/ -v --cov=src/claude_statusline --cov-report=xml --cov-report=term 2>&1 | tee pytest_output.txt
           PYTEST_EXIT=${PIPESTATUS[0]}
           set -e
@@ -100,7 +100,7 @@ jobs:
       # No Codecov upload (#125, F-DEP-004 / F-CI-008): the action was two
       # majors behind and uploaded best-effort with no token, so it never gave
       # a reliable signal. Coverage enforcement happens locally instead via
-      # --cov-fail-under=73 in pyproject.toml addopts on every matrix leg.
+      # --cov-fail-under=84 in pyproject.toml addopts on every matrix leg.
 
   # ============================================
   # INTEGRATION TESTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Publish toolchain floor: twine 7** — The `dev` extra now requires `twine>=7.0.0` (was `>=4.0.0`). The documented publish procedure (`twine check` / `twine upload`) is unchanged, but twine 7 no longer accepts metadata version 2.0 artifacts on upload; this project's hatchling-built dists emit metadata 2.5 and pass `twine check` unchanged (#135)
+- **Coverage gate raised to 84%** — `pytest --cov` invocations now enforce a `--cov-fail-under=84` floor (was 73), guarding the Sprint 4 test suites as an intermediate step toward the 94% modernization target; measured coverage is 87.59% over `src/claude_statusline` (#141)
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ State files are append-only CSV at `~/.claude/statusline/statusline.<session_id>
 # Python tests (canonical — matches docs/DEVELOPMENT.md agent setup notes)
 source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider
 
-# Coverage (enforces the --cov-fail-under=73 floor from pyproject.toml addopts)
+# Coverage (enforces the --cov-fail-under=84 floor from pyproject.toml addopts)
 pytest tests/python/ -q -p no:cacheprovider --cov=src/claude_statusline --cov-report=term
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ bats tests/bash/*.bats
 # Python tests
 pytest tests/python/ -v
 
-# Python tests with coverage (enforces the --cov-fail-under=73 floor from pyproject.toml)
+# Python tests with coverage (enforces the --cov-fail-under=84 floor from pyproject.toml)
 pytest tests/python/ -v --cov=src/claude_statusline --cov-report=term
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,15 +121,16 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests/python"]
-# Coverage floor (issue #117, F-TEST-006): measured over src/claude_statusline
-# on main — 2750 statements, 721 missed, identical across the Python 3.10-3.14
-# CI matrix legs and stable between interpreters locally. The precise total is
-# 73.78%, and coverage compares fail-under against the unrounded value, so a
-# literal 74 would fail on main itself; 73 is today's measured-value floor.
-# Raised toward the 94% M3 target by Tasks 4.6 and 5.7 of the modernization
-# plan. Inert unless coverage is requested (--cov); every invocation that does
-# request it inherits the enforcement.
-addopts = "-v --tb=short --cov-fail-under=73"
+# Coverage floor (issue #141): raised from the interim 73% floor (issue #117,
+# F-TEST-006) once Sprint 4 test tasks 4.2–4.5 (#137 batch, PR #177) landed,
+# as an intermediate step toward the 94% M3 target completed by Task 5.7.
+# Measured over src/claude_statusline — 2910 statements, 87.59% precise when
+# the gate was raised (and enforced on every CI matrix leg by this addopts
+# floor). Coverage compares fail-under against the unrounded value, so the
+# literal keeps real headroom below the measured total. Inert unless coverage
+# is requested (--cov); every invocation that does request it inherits the
+# enforcement.
+addopts = "-v --tb=short --cov-fail-under=84"
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 


### PR DESCRIPTION
Closes #141

## Summary

Raises the pytest coverage gate from `--cov-fail-under=73` to `--cov-fail-under=84` in `pyproject.toml` addopts (Task 4.6 of MODERNIZATION_PLAN.md), guarding the Sprint 4 test suites landed by Tasks 4.2–4.5 (#137 batch, PR #177). Measured coverage over `src/claude_statusline` is 87.59% (2910 statements, 361 missed), leaving ~3.6 points of headroom under the new floor. All doc/CI comment references to the old 73 figure are refreshed.

## Approach

Single-point enforcement change: the floor lives in one place — `[tool.pytest.ini_options] addopts` — and every coverage-requesting invocation (local commands of record and every CI matrix leg) inherits it by design (issue #117 rationale preserved).

## Decision Record

- **Root cause:** the gate remains pinned at the interim 73% measured-value floor set by issue #117 even though Tasks 4.2–4.5 landed enough tests to raise measured coverage to 87.59%, so the new suites were themselves unguarded.
- **Options considered:** Option 1 — raise the addopts floor to 84 and refresh stale references; Option 2 — override the floor with a CI-workflow-level `--cov-fail-under` flag; Option 3 — defer the raise into the Task 5.7 (94% target) batch.
- **Options rejected:** Option 2 — splits enforcement across two config points, contradicting the single-addopts-point design from issue #117; Option 3 — leaves the Sprint 4 suites unguarded until M3 and breaks this plan task's contract.
- **Selected option:** Option 1 — raise the addopts floor to 84 with updated rationale comments.
- **Residual risk:** removing three of the five Sprint-4 modules individually (`test_analytics_units`, `test_git_pr_cache`, `test_tokens_format`) still measures ≥84% (84.81–87.32%) — inherent to an aggregate gate; the other two trip it decisively (80.89%, 77.63%). Accepted as intermediate step; Task 5.7 continues toward 94%.
- **Effort profile:** light — fast path (pre-work Effort S); synthesis skipped, QA capped at 1 cycle

Analyzed at: `issue-141-task-4-6-raise-the-coverage-gate-to-84 @ 6b934f5973bf289698a766599789790505cb5c07` (2026-08-23)

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `--cov-fail-under` 73→84; rationale comment rewritten for issue #141 |
| `.github/workflows/ci.yml` | Comment references updated to the 84 floor (enforcement inherited, unchanged) |
| `CLAUDE.md` | Coverage command comment updated to 84 |
| `CONTRIBUTING.md` | Coverage command comment updated to 84 |
| `CHANGELOG.md` | Unreleased/Changed entry for the gate raise |

## Test Results

- Unit tests: 1319 passed (plain command of record)
- Gated run: `pytest tests/python/ -q -p no:cacheprovider --cov=src/claude_statusline --cov-fail-under=84` → 1319 passed, 87.59% total
- Mutation spot-check: `tests/python/test_cli_entry.py` removed → gate RED at 80.89% (also verified `test_report.py` → 77.63% RED; all modules restored)
- Lint/typecheck: ruff clean, mypy clean (29 source files)
- Build: n/a (no packaging change)
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| `--cov-fail-under=84` passes locally and in CI | pass | Local gated run green (87.59% ≥ 84); CI legs inherit addopts (ci.yml:72-98, comments ci.yml:80-85) |
| Removing any Sprint 4 test turns the gate red (spot-check one, revert) | pass | Removed `tests/python/test_cli_entry.py`: `Required test coverage of 84% not reached. Total coverage: 80.89%`; module restored, suite re-green |
| Test command of record passes at ≥ 616/616 plus all Sprint 4 additions | pass | `source venv/bin/activate && pytest tests/python/ -q -p no:cacheprovider` → 1319 passed |

<!-- gitissue:qa v1 head=6b934f5973bf289698a766599789790505cb5c07 profile=light cycles=1 review=clean tests=1319@6b934f5973bf289698a766599789790505cb5c07 ui=none -->
