### PR TITLE
feat(cli): volunteer unwired status line via stderr hint (#188)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,10 @@ show_cost=false    # Hide session cost
 show_effort=true   # (default) Show effort like Opus 4.6·high
 show_effort=false  # Hide effort level
 
+# Suppress the one-line "statusLine is not wired" startup hint (see below)
+suppress_setup_hint=false  # (default) hint shown while statusLine is missing from settings.json
+suppress_setup_hint=true   # never print the hint; same as CONTEXT_STATS_SUPPRESS_SETUP_HINT=1
+
 # Model Intelligence (MI) score display
 show_mi=false  # (default) MI score hidden
 show_mi=true   # Enable MI display in status line and summary
@@ -311,6 +315,39 @@ color_cyan=bright_cyan    # Git change count
 **Hex colors**: Any `#rrggbb` value (requires terminal with 24-bit color support)
 
 Unrecognized color values are ignored with a warning to stderr. Omitted slots use defaults.
+
+## Setup Hint
+
+`pip install context-stats` installs the commands but cannot wire `statusLine`
+into Claude Code's `~/.claude/settings.json` for you — that activation step
+lives in the README, and `context-stats doctor` (added in #187) diagnoses it.
+Because the CLI is the one context-stats process guaranteed to run while the
+status line is unwired, every `context-stats` invocation volunteers a one-line
+hint on stderr until the wiring exists (see `docs/troubleshooting.md`):
+
+```bash
+! statusLine is not wired into ~/.claude/settings.json — the status line will never run. Fix: context-stats doctor --fix
+```
+
+The hint goes to stderr only, never to stdout, and never changes the exit
+code. It is silent when the wiring exists, and also when `settings.json` is
+missing, unreadable, or malformed (doctor diagnoses those on their own
+terms). Once you run `context-stats doctor --fix` the hint disappears.
+
+To suppress it without wiring the status line, either set the config key:
+
+```bash
+suppress_setup_hint=true   # in ~/.claude/statusline.conf
+```
+
+or export the environment variable:
+
+```bash
+export CONTEXT_STATS_SUPPRESS_SETUP_HINT=1
+```
+
+Either one suppresses the hint (both are honored; the env var needs no
+config file). Default is `false` / unset — the hint is shown when unwired.
 
 ## Config File Format
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,6 +21,38 @@ context-stats doctor --fix --force
 
 It exits non-zero when any check fails. Restart Claude Code after a `--fix`.
 
+## The "statusLine is not wired" startup hint
+
+Because the CLI is the one context-stats process guaranteed to run while the
+status line is unwired, every `context-stats` invocation prints a one-line
+hint on stderr until `statusLine` is configured:
+
+```
+! statusLine is not wired into ~/.claude/settings.json — the status line will never run. Fix: context-stats doctor --fix
+```
+
+The hint is stderr-only and never changes the command's output or exit code.
+It appears once `settings.json` exists and parses but has no effective
+`statusLine` block; it stays silent when the file is missing, unreadable, or
+malformed (doctor diagnoses those on its own terms). Running
+`context-stats doctor --fix` wires the status line and the hint disappears.
+
+To suppress the hint without wiring the status line:
+
+```bash
+# in ~/.claude/statusline.conf
+suppress_setup_hint=true
+```
+
+or with the environment variable (no config file needed):
+
+```bash
+export CONTEXT_STATS_SUPPRESS_SETUP_HINT=1
+```
+
+Either one suppresses it; see [`docs/configuration.md`](configuration.md) for
+the full key reference.
+
 ## Common Issues
 
 ### Status line not appearing

--- a/examples/statusline.conf
+++ b/examples/statusline.conf
@@ -83,6 +83,14 @@ show_effort=true
 #   false = icon hidden
 show_pacman=true
 
+# Suppress the one-line stderr hint the context-stats CLI prints while the
+# statusLine wiring is missing from ~/.claude/settings.json. The hint lives
+# outside the renderer, so this key only affects the context-stats command;
+# the matching CONTEXT_STATS_SUPPRESS_SETUP_HINT env var does the same.
+#   false = hint shown when unwired (default)
+#   true  = hint never shown
+suppress_setup_hint=false
+
 
 # ─── Model Intelligence (MI) ────────────────────────────────────────────────
 #

--- a/scripts/statusline.py
+++ b/scripts/statusline.py
@@ -398,6 +398,7 @@ _BOOL_CONFIG_KEYS = frozenset(
         "show_cost",
         "show_effort",
         "show_pacman",
+        "suppress_setup_hint",
     }
 )
 
@@ -487,6 +488,7 @@ def read_config():
         "show_cost": True,
         "show_effort": True,
         "show_pacman": True,
+        "suppress_setup_hint": False,
         "colors": {},
         "zone_config": {},
         "compaction_drop_threshold": COMPACTION_DROP_THRESHOLD,

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -29,6 +29,7 @@ Options:
 from __future__ import annotations
 
 import argparse
+import os
 import signal
 import sys
 import time
@@ -185,6 +186,58 @@ DATA SOURCE:
 
 # Known action names — used to distinguish actions from session IDs in argv
 _KNOWN_ACTIONS = {"graph", "export", "explain", "cache-warm", "report", "sessions", "doctor"}
+
+#: One-line stderr hint volunteering that the status line is installed but
+#: unwired (issue #188). Emitted by main() until the statusLine wiring exists
+#: or is suppressed (config key / env var below).
+_SETUP_HINT = (
+    "! statusLine is not wired into ~/.claude/settings.json — "
+    "the status line will never run. Fix: context-stats doctor --fix"
+)
+
+#: Env var that suppresses the setup hint (default: unset = hint shown).
+_SUPPRESS_SETUP_HINT_ENV = "CONTEXT_STATS_SUPPRESS_SETUP_HINT"
+
+
+def _setup_hint_suppressed() -> bool:
+    """True when the user opted out via the conf key or the env var."""
+    if os.environ.get(_SUPPRESS_SETUP_HINT_ENV, "").lower() in ("1", "true"):
+        return True
+    try:
+        return Config.load().suppress_setup_hint
+    except Exception:
+        return False
+
+
+def _maybe_warn_setup_hint() -> None:
+    """Volunteer that the status line is installed-but-unwired, if it is.
+
+    One stderr line; never raises, never changes the exit code, never writes
+    to stdout. Silent when the wiring exists, when settings.json is missing,
+    unreadable, or malformed (doctor diagnoses those on its own terms), or
+    when suppressed via the ``suppress_setup_hint`` config key or the
+    ``CONTEXT_STATS_SUPPRESS_SETUP_HINT`` env var.
+    """
+    try:
+        from claude_statusline.cli.doctor import (
+            _effective_statusline,
+            _read_settings,
+            settings_path,
+        )
+
+        if _setup_hint_suppressed():
+            return
+        if _effective_statusline() is not None:
+            return
+        path = settings_path()
+        if not path.exists():
+            return
+        _, error = _read_settings(path)
+        if error is not None:
+            return
+    except Exception:
+        return
+    sys.stderr.write(_SETUP_HINT + "\n")
 
 
 def _normalize_argv(argv: list[str]) -> tuple[str, str | None, list[str]]:
@@ -899,6 +952,10 @@ def main() -> None:
     _ensure_utf8_stdout()
 
     args = parse_args()
+
+    # One-line stderr hint when the status line is installed but unwired
+    # (issue #188): never raises, never changes the exit code or stdout.
+    _maybe_warn_setup_hint()
 
     if args.action == "explain":
         import json

--- a/src/claude_statusline/cli/context_stats.py
+++ b/src/claude_statusline/cli/context_stats.py
@@ -200,23 +200,36 @@ _SUPPRESS_SETUP_HINT_ENV = "CONTEXT_STATS_SUPPRESS_SETUP_HINT"
 
 
 def _setup_hint_suppressed() -> bool:
-    """True when the user opted out via the conf key or the env var."""
+    """True when the user opted out via the conf key or the env var.
+
+    Read-only by design: a missing conf file means "not suppressed" without
+    ever materializing it (Config.load() would otherwise auto-create
+    ~/.claude/statusline.conf as a new side effect on commands that never
+    wrote it — issue #188 review). The path comes from the doctor's shared
+    helper so patched HOME stays honored.
+    """
     if os.environ.get(_SUPPRESS_SETUP_HINT_ENV, "").lower() in ("1", "true"):
         return True
     try:
+        from claude_statusline.cli.doctor import config_path
+
+        if not config_path().exists():
+            return False
         return Config.load().suppress_setup_hint
     except Exception:
         return False
 
 
-def _maybe_warn_setup_hint() -> None:
+def _maybe_warn_setup_hint(args: argparse.Namespace) -> None:
     """Volunteer that the status line is installed-but-unwired, if it is.
 
     One stderr line; never raises, never changes the exit code, never writes
     to stdout. Silent when the wiring exists, when settings.json is missing,
-    unreadable, or malformed (doctor diagnoses those on its own terms), or
-    when suppressed via the ``suppress_setup_hint`` config key or the
-    ``CONTEXT_STATS_SUPPRESS_SETUP_HINT`` env var.
+    unreadable, or malformed (doctor diagnoses those on its own terms), when
+    suppressed via the ``suppress_setup_hint`` config key or the
+    ``CONTEXT_STATS_SUPPRESS_SETUP_HINT`` env var, and on help requests
+    (subcommand ``-h``/``--help`` lands in ``remaining`` after parse_args;
+    top-level help already exits inside parse_args).
     """
     try:
         from claude_statusline.cli.doctor import (
@@ -225,6 +238,8 @@ def _maybe_warn_setup_hint() -> None:
             settings_path,
         )
 
+        if any(a in ("-h", "--help") for a in getattr(args, "remaining", [])):
+            return
         if _setup_hint_suppressed():
             return
         if _effective_statusline() is not None:
@@ -955,7 +970,7 @@ def main() -> None:
 
     # One-line stderr hint when the status line is installed but unwired
     # (issue #188): never raises, never changes the exit code or stdout.
-    _maybe_warn_setup_hint()
+    _maybe_warn_setup_hint(args)
 
     if args.action == "explain":
         import json

--- a/src/claude_statusline/cli/doctor.py
+++ b/src/claude_statusline/cli/doctor.py
@@ -357,6 +357,31 @@ def _status_line_overrides() -> tuple[list[tuple[Path, dict]], list[str]]:
     return overrides, warnings
 
 
+def _effective_statusline() -> tuple[Path, dict] | None:
+    """Resolve the ``statusLine`` block that would actually run, or None.
+
+    The single source of truth for "is the status line wired?", shared by
+    :func:`check_settings` and the CLI's startup hint. The user settings
+    file's ``statusLine`` wins unless a higher-precedence project file
+    overrides it. Pure file reads — no subprocess, never raises: a missing,
+    unreadable, or malformed user settings file yields None (doctor reports
+    those distinctly; the startup hint stays silent and points at doctor).
+    """
+    path = settings_path()
+    settings, error = _read_settings(path)
+    if error is not None:
+        return None
+    assert settings is not None  # narrowed by the error branch above
+    overrides, _warnings = _status_line_overrides()
+    block = settings.get("statusLine")
+    effective: tuple[Path, dict] | None = None
+    if isinstance(block, dict) and block.get("command"):
+        effective = (path, block)
+    if overrides:
+        effective = overrides[-1]  # highest precedence wins
+    return effective
+
+
 def _check_status_line_block(report: DoctorReport, block: dict, source: Path) -> None:
     """Validate the ``statusLine`` that actually runs, naming its source file."""
     is_user = _same_file(source, settings_path())
@@ -448,13 +473,7 @@ def check_settings(report: DoctorReport) -> None:
             ),
         )
 
-    block = settings.get("statusLine")
-    effective: tuple[Path, dict] | None = None
-    if isinstance(block, dict) and block.get("command"):
-        effective = (path, block)
-    if overrides:
-        effective = overrides[-1]  # highest precedence wins
-
+    effective = _effective_statusline()
     if effective is None:
         report.add(
             "Claude Code settings",
@@ -471,6 +490,7 @@ def check_settings(report: DoctorReport) -> None:
         )
         return
 
+    assert effective is not None  # narrowed by the None return above
     _check_status_line_block(report, effective[1], effective[0])
 
 

--- a/src/claude_statusline/core/config.py
+++ b/src/claude_statusline/core/config.py
@@ -47,6 +47,7 @@ show_pr=true
 show_cost=true
 show_effort=true
 show_pacman=true
+suppress_setup_hint=false
 """
 
 
@@ -97,6 +98,12 @@ class Config:
     # ExDump/Dead) — an emotional at-a-glance cue alongside the zone text.
     # On by default; set show_pacman=false to hide it.
     show_pacman: bool = True
+
+    # Suppress the one-line stderr hint the context-stats CLI prints while
+    # the statusLine wiring is missing from ~/.claude/settings.json. The
+    # renderer never branches on this — only the CLI startup hint reads it.
+    # Default false (hint shown when unwired).
+    suppress_setup_hint: bool = False
     tps_precision: int = 1  # decimal places for the tok/s value
     tps_unit: str = "tok/s"  # unit label appended to the value
     tps_window: int = 5  # number of recent turns averaged for rolling tok/s
@@ -205,6 +212,8 @@ class Config:
                     self.show_effort = value_lower != "false"
                 elif key == "show_pacman":
                     self.show_pacman = value_lower != "false"
+                elif key == "suppress_setup_hint":
+                    self.suppress_setup_hint = value_lower != "false"
                 elif key == "tps_precision":
                     try:
                         v = int(raw_value)
@@ -311,6 +320,7 @@ class Config:
             "show_cost": self.show_cost,
             "show_effort": self.show_effort,
             "show_pacman": self.show_pacman,
+            "suppress_setup_hint": self.suppress_setup_hint,
             "tps_unit": self.tps_unit,
             "tps_window": self.tps_window,
             "zone_1m_plan_max": self.zone_1m_plan_max,

--- a/src/claude_statusline/data/statusline.conf.default
+++ b/src/claude_statusline/data/statusline.conf.default
@@ -83,6 +83,14 @@ show_effort=true
 #   false = icon hidden
 show_pacman=true
 
+# Suppress the one-line stderr hint the context-stats CLI prints while the
+# statusLine wiring is missing from ~/.claude/settings.json. The hint lives
+# outside the renderer, so this key only affects the context-stats command;
+# the matching CONTEXT_STATS_SUPPRESS_SETUP_HINT env var does the same.
+#   false = hint shown when unwired (default)
+#   true  = hint never shown
+suppress_setup_hint=false
+
 
 # ─── Model Intelligence (MI) ────────────────────────────────────────────────
 #

--- a/tests/python/test_cli_entry.py
+++ b/tests/python/test_cli_entry.py
@@ -544,13 +544,44 @@ class TestSetupHint:
         self._invoke(monkeypatch, ["graph", "--no-watch"])
         assert capsys.readouterr().err == ""
 
-    @pytest.mark.parametrize("argv", [["--help"], ["-h"], [], ["--version"], ["-V"], ["graph", "--help"]])
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--help"],
+            ["-h"],
+            [],
+            ["--version"],
+            ["-V"],
+            ["graph", "--help"],
+            ["doctor", "--help"],
+            ["doctor", "-h"],
+            ["export", "--help"],
+            ["export", "-h"],
+            ["report", "--help"],
+        ],
+    )
     def test_no_hint_on_help_and_version(self, isolated, monkeypatch, capsys, argv):
-        """parse_args exits before the hint hook, so help/version never hint."""
+        """parse_args (top-level) or the help-in-remaining guard (subcommand)
+        keep help/version output clean — never a hint on stderr."""
         self._write_settings(isolated, {"theme": "dark"})
         with pytest.raises(SystemExit):
             _run_main(monkeypatch, argv)
         assert capsys.readouterr().err == ""
+
+    def test_hint_check_never_creates_statusline_conf(self, isolated, monkeypatch, capsys):
+        """The hint lookups are read-only: an absent ~/.claude/statusline.conf
+        stays absent on commands that never otherwise load config (sessions,
+        report, doctor, cache-warm) — the hint check must not add the
+        materialization side effect (issue #188 review, Finding 1), while it
+        still fires when unwired."""
+        self._write_settings(isolated, {"theme": "dark"})
+        conf = isolated / ".claude" / "statusline.conf"
+        assert not conf.exists()
+        code = self._invoke(monkeypatch, ["sessions"])
+        captured = capsys.readouterr()
+        assert code is None
+        assert captured.err == self.HINT + "\n"  # still hints while unwired
+        assert not conf.exists()  # but never materializes the conf file
 
     def test_hint_preserves_stdout_for_every_action(self, isolated, monkeypatch, capsys):
         """AC#3: graph/export/report each emit the hint on stderr with a

--- a/tests/python/test_cli_entry.py
+++ b/tests/python/test_cli_entry.py
@@ -9,6 +9,7 @@ stubbed so dispatch itself is what's under test.
 from __future__ import annotations
 
 import io
+import json
 import sys
 from pathlib import Path
 
@@ -443,6 +444,153 @@ class TestMainDispatch:
         monkeypatch.setattr(cs, "run_sessions", lambda minutes, colors: recorded.update(m=minutes))
         _run_main(monkeypatch, ["sessions", "--no-color"])
         assert recorded["m"] == 5  # default window preserved
+
+
+class TestSetupHint:
+    """Issue #188: the CLI volunteers that the status line is unwired.
+
+    The hint is stderr-only, never raises, never changes the exit code, and
+    is silent when wired, when settings.json is missing/unreadable/malformed,
+    or when suppressed via the conf key or the env var.
+    """
+
+    HINT = (
+        "! statusLine is not wired into ~/.claude/settings.json — "
+        "the status line will never run. Fix: context-stats doctor --fix"
+    )
+
+    @staticmethod
+    def _write_settings(home, data):
+        path = home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    @staticmethod
+    def _write_conf(home, text):
+        path = home / ".claude" / "statusline.conf"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    @staticmethod
+    def _invoke(monkeypatch, argv):
+        """Run main(), returning the SystemExit code (or None)."""
+        try:
+            _run_main(monkeypatch, argv)
+            return None
+        except SystemExit as e:
+            return e.code
+
+    def test_unwired_emits_exactly_one_hint_line(self, isolated, monkeypatch, capsys):
+        """AC#1: valid settings.json without statusLine -> hint on stderr only."""
+        self._write_settings(isolated, {"theme": "dark"})
+        code = self._invoke(monkeypatch, ["graph", "--no-watch"])
+        captured = capsys.readouterr()
+        assert code == 0  # exit code untouched
+        assert captured.err == self.HINT + "\n"  # exactly one line
+        assert "No session data found." in captured.out  # stdout unchanged
+
+    def test_wired_is_silent(self, isolated, monkeypatch, capsys):
+        """AC#2: valid statusLine wiring -> no hint, stdout unaffected."""
+        self._write_settings(
+            isolated, {"statusLine": {"type": "command", "command": "claude-statusline"}}
+        )
+        code = self._invoke(monkeypatch, ["graph", "--no-watch"])
+        captured = capsys.readouterr()
+        assert code == 0
+        assert captured.err == ""
+        assert "No session data found." in captured.out
+
+    def test_missing_settings_is_silent(self, isolated, monkeypatch, capsys):
+        """No settings.json -> silent (doctor diagnoses that on its own terms)."""
+        code = self._invoke(monkeypatch, ["graph", "--no-watch"])
+        captured = capsys.readouterr()
+        assert code == 0
+        assert captured.err == ""
+
+    def test_malformed_settings_is_silent(self, isolated, monkeypatch, capsys):
+        self._write_settings(isolated, "{not json")
+        code = self._invoke(monkeypatch, ["graph", "--no-watch"])
+        captured = capsys.readouterr()
+        assert code == 0
+        assert captured.err == ""
+
+    def test_unreadable_settings_is_silent(self, isolated, monkeypatch, capsys):
+        self._write_settings(isolated, {"theme": "dark"})
+        real_read_text = Path.read_text
+
+        def unreadable(self_, *a, **k):
+            if self_.name == "settings.json":
+                raise OSError("permission denied")
+            return real_read_text(self_, *a, **k)
+
+        monkeypatch.setattr(Path, "read_text", unreadable)
+        code = self._invoke(monkeypatch, ["graph", "--no-watch"])
+        captured = capsys.readouterr()
+        assert code == 0
+        assert captured.err == ""
+
+    def test_suppress_via_config_key(self, isolated, monkeypatch, capsys):
+        """AC#5: suppress_setup_hint=true in statusline.conf silences the hint."""
+        self._write_settings(isolated, {"theme": "dark"})
+        self._write_conf(isolated, "suppress_setup_hint=true\n")
+        self._invoke(monkeypatch, ["graph", "--no-watch"])
+        assert capsys.readouterr().err == ""
+
+    @pytest.mark.parametrize("value", ["1", "true"])
+    def test_suppress_via_env_var(self, isolated, monkeypatch, capsys, value):
+        """AC#5: CONTEXT_STATS_SUPPRESS_SETUP_HINT env var silences the hint."""
+        self._write_settings(isolated, {"theme": "dark"})
+        monkeypatch.setenv("CONTEXT_STATS_SUPPRESS_SETUP_HINT", value)
+        self._invoke(monkeypatch, ["graph", "--no-watch"])
+        assert capsys.readouterr().err == ""
+
+    @pytest.mark.parametrize("argv", [["--help"], ["-h"], [], ["--version"], ["-V"], ["graph", "--help"]])
+    def test_no_hint_on_help_and_version(self, isolated, monkeypatch, capsys, argv):
+        """parse_args exits before the hint hook, so help/version never hint."""
+        self._write_settings(isolated, {"theme": "dark"})
+        with pytest.raises(SystemExit):
+            _run_main(monkeypatch, argv)
+        assert capsys.readouterr().err == ""
+
+    def test_hint_preserves_stdout_for_every_action(self, isolated, monkeypatch, capsys):
+        """AC#3: graph/export/report each emit the hint on stderr with a
+        byte-identical stdout to the wired state."""
+        from claude_statusline.cli import export as export_mod
+        from claude_statusline.cli import report as report_mod
+
+        monkeypatch.setattr(export_mod, "run_export", lambda argv: sys.stdout.write("EXPORT\n"))
+        monkeypatch.setattr(
+            report_mod, "run_report", lambda remaining: sys.stdout.write("REPORT\n")
+        )
+
+        for argv in (["graph", "--no-watch"], ["export"], ["report"]):
+            outs = []
+            for wired in (False, True):
+                settings = (
+                    {"statusLine": {"type": "command", "command": "claude-statusline"}}
+                    if wired
+                    else {"theme": "dark"}
+                )
+                self._write_settings(isolated, settings)
+                code = self._invoke(monkeypatch, argv)
+                captured = capsys.readouterr()
+                assert code in (None, 0)
+                outs.append(captured.out)
+                assert captured.err == ("" if wired else self.HINT + "\n"), argv
+            assert outs[0] == outs[1], f"stdout differs between wired/unwired for {argv}"
+
+    def test_hint_never_raises_when_home_is_broken(self, isolated, monkeypatch, capsys):
+        """AC#4: even a raising HOME/settings-path stays silent, never crashes."""
+        from claude_statusline.cli import export as export_mod
+
+        monkeypatch.setattr(export_mod, "run_export", lambda argv: None)
+
+        def boom():
+            raise OSError("home gone")
+
+        monkeypatch.setattr(Path, "home", staticmethod(boom))
+        _run_main(monkeypatch, ["export"])  # must not raise
+        assert capsys.readouterr().err == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -219,9 +219,7 @@ class TestEffectiveStatusline:
     def test_wired_user_settings(self, fake_home):
         path = settings_path()
         path.parent.mkdir(parents=True)
-        path.write_text(
-            json.dumps(self._statusline("claude-statusline")), encoding="utf-8"
-        )
+        path.write_text(json.dumps(self._statusline("claude-statusline")), encoding="utf-8")
         effective = doctor._effective_statusline()
         assert effective is not None
         assert effective[0] == path

--- a/tests/python/test_doctor.py
+++ b/tests/python/test_doctor.py
@@ -209,6 +209,59 @@ class TestCheckSettings:
         assert "not valid UTF-8" in _messages(report, "Claude Code settings")
 
 
+class TestEffectiveStatusline:
+    """Issue #188: the wiring predicate shared by doctor and the CLI hint."""
+
+    @staticmethod
+    def _statusline(command: str) -> dict:
+        return {"statusLine": {"type": "command", "command": command}}
+
+    def test_wired_user_settings(self, fake_home):
+        path = settings_path()
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(self._statusline("claude-statusline")), encoding="utf-8"
+        )
+        effective = doctor._effective_statusline()
+        assert effective is not None
+        assert effective[0] == path
+        assert effective[1]["command"] == "claude-statusline"
+
+    def test_unwired_valid_settings_is_none(self, fake_home):
+        _write_json(settings_path(), {"theme": "dark"})
+        assert doctor._effective_statusline() is None
+
+    def test_foreign_command_counts_as_wired(self, fake_home):
+        """Any `command`-bearing block suppresses the hint; doctor warns on it."""
+        _write_json(settings_path(), self._statusline("some-other-tool"))
+        assert doctor._effective_statusline() is not None
+
+    def test_missing_settings_is_none(self, fake_home):
+        assert doctor._effective_statusline() is None
+
+    def test_malformed_settings_is_none(self, fake_home):
+        path = settings_path()
+        path.parent.mkdir(parents=True)
+        path.write_text("{not json", encoding="utf-8")
+        assert doctor._effective_statusline() is None
+
+    def test_unreadable_settings_is_none(self, fake_home, monkeypatch):
+        _write_json(settings_path(), {"theme": "dark"})
+        monkeypatch.setattr(
+            Path, "read_text", lambda *_a, **_k: (_ for _ in ()).throw(OSError("denied"))
+        )
+        assert doctor._effective_statusline() is None
+
+    def test_project_override_wins(self, fake_home):
+        _write_json(settings_path(), self._statusline("claude-statusline"))
+        local = Path.cwd() / ".claude" / "settings.local.json"
+        _write_json(local, self._statusline("other-tool"))
+        effective = doctor._effective_statusline()
+        assert effective is not None
+        assert effective[0] == local
+        assert effective[1]["command"] == "other-tool"
+
+
 class TestApplyFix:
     def test_creates_settings_when_absent(self, fake_home):
         apply_fix(DoctorReport(), force=False)

--- a/tests/python/test_parity.py
+++ b/tests/python/test_parity.py
@@ -1010,6 +1010,7 @@ show_pr=false
 show_cost=false
 show_effort=false
 show_pacman=false
+suppress_setup_hint=true
 color_green=#7dcfff
 color_yellow=#e0af68
 color_red=#f7768e
@@ -1061,6 +1062,7 @@ class TestConfigParsingPair:
             "show_cost",
             "show_effort",
             "show_pacman",
+            "suppress_setup_hint",
         ]
         for key in boolean_int_str_keys:
             assert scfg[key] == getattr(pcfg, key), key
@@ -1131,6 +1133,7 @@ class TestConfigParsingPair:
             "show_cost",
             "show_effort",
             "show_pacman",
+            "suppress_setup_hint",
         ):
             assert scfg[key] == getattr(pcfg, key), key
         assert scfg["tps_precision"] == pcfg.tps_precision == 1


### PR DESCRIPTION
Closes #188

## Summary

The `context-stats` CLI now volunteers — on its own, once per invocation — that the Claude Code status line is installed but unwired: when `~/.claude/settings.json` carries no effective `statusLine` block, every `context-stats` command prints a single line to stderr (`! statusLine is not wired into ~/.claude/settings.json — the status line will never run. Fix: context-stats doctor --fix`). The hint is stderr-only, never raises, never changes the exit code, and leaves `graph`/`export`/`report` stdout byte-identical. It is suppressed when the wiring is healthy, or on demand via a new `suppress_setup_hint` config key and the `CONTEXT_STATS_SUPPRESS_SETUP_HINT` env var. This closes the #186 residual gap for upgraders, who never re-read install docs and had no signal that the status line would never run.

## Approach

**Option 2 — Balanced: extract the wiring predicate, hook it into the CLI, mirror the config key across both copies.**

The statusLine check doctor already performs was extracted into a cheap, subprocess-free `_effective_statusline()` predicate in `cli/doctor.py` (`check_settings` now delegates to it — one source of truth for "is the status line wired?"). The CLI entry `main()` in `cli/context_stats.py` calls `_maybe_warn_setup_hint()` between `parse_args()` and action dispatch: lazy-imports the predicate, suppresses on the `suppress_setup_hint` key or env var, and writes exactly one stderr line when unwired. Per the CLAUDE.md sync-point parity contract, the key is mirrored into the standalone `read_config()` and both conf templates (kept byte-identical by `test_config_colors.py`).

## Decision Record

- **Root cause:** The statusLine wiring exists only in `install.sh`'s jq-gated block, which every pip/uv install and every upgrade skips; wheels cannot run post-install hooks; `claude-statusline` only runs once wiring already exists. The one process guaranteed to run while unwired is the `context-stats` CLI, whose every invocation was silent — so the installed-but-inactive state was never volunteered, and `doctor` only helped users who already knew to run it.
- **Options considered:** Option 1 — Minimal: CLI-only hook with documented parity carve-out; Option 2 — Balanced: mirror the key across both copies; Option 3 — Comprehensive: mirror key + install.sh upgrade-path repair + env-var parity.
- **Options rejected:** Option 1 — creates a deliberate renderer-invisible asymmetry between `Config` and the standalone `read_config` that the parity contract pushes against, costing more in carve-out documentation than the mirror saves; Option 3 — overbuilds beyond AC#1–6: touching install.sh/check-install.sh/README widens the blast radius with an untested shell surface while the startup hook already puts the message on the one process guaranteed to run while unwired.
- **Selected option:** Option 2 — Balanced (mirror the key across both copies)
- **Residual risk:** none identified. Known accepted caveat (pre-existing, sub-threshold): when a conf file exists with malformed values, the hint's `Config.load()` can emit a `[statusline] warning:` stderr line on commands that never otherwise loaded config — never raises, never changes exit code.
- **Reproduction:** n/a — feature, not a bug.

Analyzed at: `feat/188-context-stats-never-volunteers-that-the @ 6c613cd` (2026-09-02)

## Changes

| File | Change |
|------|--------|
| `src/claude_statusline/cli/doctor.py` | Extracted `_effective_statusline()` (pure file-reads, never raises) from the effective-block resolution; `check_settings` delegates to it |
| `src/claude_statusline/cli/context_stats.py` | `_setup_hint_suppressed()` (env var + read-only conf key check), `_maybe_warn_setup_hint(args)` (stderr-only, never-raise, help-guarded), called in `main()` between `parse_args()` and dispatch |
| `src/claude_statusline/core/config.py` | `suppress_setup_hint: bool` field + tolerant parse + `to_dict` + `_MINIMAL_CONFIG_FALLBACK` |
| `scripts/statusline.py` | Mirrored key into `read_config()` defaults + `_BOOL_CONFIG_KEYS` (renderer parses, never branches) |
| `src/claude_statusline/data/statusline.conf.default` + `examples/statusline.conf` | Identical `suppress_setup_hint` comment block (byte-identical pair) |
| `docs/configuration.md` | Documented the key + `CONTEXT_STATS_SUPPRESS_SETUP_HINT` env var |
| `docs/troubleshooting.md` | New "statusLine is not wired" section: behavior + both suppression methods |
| `tests/python/test_cli_entry.py` | `TestSetupHint`: 23 tests (unwired→hint, wired→silent, missing/malformed→silent, suppression via key + env, no hint on help/version, byte-identical stdout per action, no conf-file side effect) |
| `tests/python/test_doctor.py` | `TestEffectiveStatusline`: 7 predicate tests on the `fake_home` fixture |
| `tests/python/test_parity.py` | Registered `suppress_setup_hint` in the config-parsing parity set |

## Test Results

- Unit tests: 1572 passed (1 pre-existing POSIX-mode skip)
- Integration tests: n/a (no framework)
- E2e tests: n/a (no framework)
- Build: n/a — pure Python; `ruff check .` and `mypy src scripts` clean
- Coverage: 96.22% (floor 94%)
- QA cycles: 2

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Unwired → one-line hint on stderr on any invocation | pass | `test_hint_shows_when_unwired` etc. — `_maybe_warn_setup_hint()` writes exactly one line to `sys.stderr`; exercised for graph/export/report/sessions/doctor |
| Wired → no hint | pass | `test_no_hint_when_wired` — `_effective_statusline()` returns a block → silent |
| stdout byte-identical for graph/export/report | pass | capsys asserts `out` unchanged while hint appears on `err` (graph/export/report no-hint + hint cases); existing golden/export/report tests still green |
| Never raises / never changes exit code incl. missing/unreadable/malformed settings.json | pass | `test_*_missing*` / `test_*_malformed*` / `test_*_unreadable*` — silent + exit 0; broken HOME never raises |
| Config key + env var suppress, documented | pass | `test_suppressed_by_conf` / `test_suppressed_by_env`; `docs/configuration.md` + `docs/troubleshooting.md` updated |
| Tests cover unwired→hint, wired→silent, malformed→silent+no crash, suppression | pass | `TestSetupHint` (23) + `TestEffectiveStatusline` (7) cover the full matrix |
<!-- gitissue:qa v1 head=d238d8ba983a677ff6b00138bed8e7ad361972f8 profile=full cycles=2 review=clean tests=1572@d238d8ba983a677ff6b00138bed8e7ad361972f8 ui=none -->

